### PR TITLE
deps: bump Rust toolchain from 1.89.0 to 1.94.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SpaceCat 🔭
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Rust](https://img.shields.io/badge/rust-1.89+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.94+-orange.svg)](https://www.rust-lang.org)
 [![Build Status](https://github.com/theatrus/spacecat/workflows/CI/badge.svg)](https://github.com/theatrus/spacecat/actions)
 
 **SpaceCat** is a Rust-based tool for posting events to multiple chat services (Discord, Matrix) from a [NINA](https://nighttime-imaging.eu)
@@ -237,7 +237,7 @@ spacecat.exe windows-service uninstall
 
 ### Prerequisites
 
-- **Rust 1.89+**: Install from [rustup.rs](https://rustup.rs/)
+- **Rust 1.94+**: Install from [rustup.rs](https://rustup.rs/)
 - **Git**: For version control
 - **OpenSSL development headers**: For HTTPS support
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,7 +1,7 @@
 # SpaceCat 🔭
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Rust](https://img.shields.io/badge/rust-1.89+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.94+-orange.svg)](https://www.rust-lang.org)
 [![Build Status](https://github.com/theatrus/spacecat/workflows/CI/badge.svg)](https://github.com/theatrus/spacecat/actions)
 
 **SpaceCat** is a Rust-based tool for posting to Discord events from a [NINA](https://nighttime-imaging.eu)
@@ -165,7 +165,7 @@ spacecat.exe windows-service uninstall
 
 ### Prerequisites
 
-- **Rust 1.89+**: Install from [rustup.rs](https://rustup.rs/)
+- **Rust 1.94+**: Install from [rustup.rs](https://rustup.rs/)
 - **Git**: For version control
 - **OpenSSL development headers**: For HTTPS support
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 profile = "default"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod api;
 pub mod autofocus;
 pub mod chat;


### PR DESCRIPTION
## Summary
- Bumps Rust toolchain from 1.89.0 to 1.94.1 (latest stable)
- Adds `#![recursion_limit = "256"]` to `src/lib.rs` — needed because the newer compiler hits the default recursion limit with matrix-sdk's deep type nesting
- Updates MSRV badge in README.md and installer/README.md

## Test plan
- [x] `cargo test` — all 36 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)