### PR TITLE
events: enrich notifications and infer NINA state at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 config.json
+config.*.json
 *.log
-config.json
 /installer/output
 .vscode/

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,8 @@
 use crate::autofocus::AutofocusResponse;
 use crate::config::ApiConfig;
 use crate::events::EventHistoryResponse;
+use crate::filterwheel::FilterWheelInfoResponse;
+use crate::guider::GuiderInfoResponse;
 use crate::images::{ImageHistoryResponse, ImageResponse, ThumbnailResponse};
 use crate::mount::MountInfoResponse;
 use crate::sequence::SequenceResponse;
@@ -350,6 +352,18 @@ impl SpaceCatApiClient {
         params: &[(&str, &str)],
     ) -> Result<MountInfoResponse, ApiError> {
         self.generic_request_with_retry("/equipment/mount/info", params)
+            .await
+    }
+
+    /// Fetch current filter wheel state from the /equipment/filterwheel/info endpoint
+    pub async fn get_filterwheel_info(&self) -> Result<FilterWheelInfoResponse, ApiError> {
+        self.generic_request_with_retry("/equipment/filterwheel/info", &[])
+            .await
+    }
+
+    /// Fetch current guider state from the /equipment/guider/info endpoint
+    pub async fn get_guider_info(&self) -> Result<GuiderInfoResponse, ApiError> {
+        self.generic_request_with_retry("/equipment/guider/info", &[])
             .await
     }
 }

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -3,12 +3,12 @@ use crate::autofocus::AutofocusResponse;
 use crate::chat::{ChatField, ChatMessage, ChatServiceManager};
 use crate::discord::colors;
 use crate::events::{Event, EventDetails, FilterInfo, TargetCoordinates, event_types};
-use chrono::{DateTime, FixedOffset, Utc};
 use crate::images::ImageMetadata;
 use crate::sequence::{
     SequenceResponse, extract_current_target, extract_meridian_flip_time,
     meridian_flip_time_formatted_with_clock,
 };
+use chrono::{DateTime, FixedOffset, Utc};
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -751,7 +751,10 @@ impl ChatUpdater {
 
         if let Some(end) = self.state.wait_until {
             let now = Utc::now();
-            let minutes = end.with_timezone(&Utc).signed_duration_since(now).num_minutes();
+            let minutes = end
+                .with_timezone(&Utc)
+                .signed_duration_since(now)
+                .num_minutes();
             if minutes > 0 {
                 parts.push(format!(
                     "⏳ Waiting until {} ({} min remaining)",
@@ -957,8 +960,11 @@ impl ChatUpdater {
             let g = &info.response;
             message = message.field("State", &g.state, true);
             if g.pixel_scale > 0.0 {
-                message =
-                    message.field("Pixel Scale", &format!("{:.3} arcsec/px", g.pixel_scale), true);
+                message = message.field(
+                    "Pixel Scale",
+                    &format!("{:.3} arcsec/px", g.pixel_scale),
+                    true,
+                );
             }
             if let Some(rms) = &g.rms_error {
                 message = message.field(

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -2,7 +2,8 @@ use crate::api::SpaceCatApiClient;
 use crate::autofocus::AutofocusResponse;
 use crate::chat::{ChatField, ChatMessage, ChatServiceManager};
 use crate::discord::colors;
-use crate::events::{Event, EventDetails, TargetCoordinates, event_types};
+use crate::events::{Event, EventDetails, FilterInfo, TargetCoordinates, event_types};
+use chrono::{DateTime, FixedOffset, Utc};
 use crate::images::ImageMetadata;
 use crate::sequence::{
     SequenceResponse, extract_current_target, extract_meridian_flip_time,
@@ -37,6 +38,15 @@ struct UpdaterState {
     sequence: Option<SequenceResponse>,
     last_image_time: Option<Instant>,
     skipped_images_count: u32,
+    last_filter: Option<FilterInfo>,
+    /// Latest mount-state event we've observed (PARKED, UNPARKED, HOMED, etc.).
+    last_mount_event: Option<String>,
+    /// Latest guider-state event we've observed (START, STOP, DITHER).
+    last_guider_event: Option<String>,
+    /// True if the last sequence event was STARTING (not FINISHED).
+    sequence_running: bool,
+    /// Active TS-WAITSTART wait-end time, if NINA is currently waiting.
+    wait_until: Option<DateTime<FixedOffset>>,
 }
 
 impl UpdaterState {
@@ -49,6 +59,11 @@ impl UpdaterState {
             sequence: None,
             last_image_time: None,
             skipped_images_count: 0,
+            last_filter: None,
+            last_mount_event: None,
+            last_guider_event: None,
+            sequence_running: false,
+            wait_until: None,
         }
     }
 
@@ -169,6 +184,11 @@ impl ChatUpdater {
             println!("Current target: {} (from {:?})", target.name, target.source);
         }
 
+        let status = self.format_startup_status();
+        if !status.is_empty() {
+            println!("Inferred NINA state:\n{status}");
+        }
+
         println!("Now monitoring for new events and images...\n");
 
         // Send welcome message to chat services
@@ -187,8 +207,18 @@ impl ChatUpdater {
             if event.event == event_types::FILTERWHEEL_CHANGED
                 && let Some(EventDetails::FilterWheelChange { new, previous }) = &event.details
                 && new.name == previous.name
+                && !new.is_unknown()
             {
                 continue;
+            }
+
+            // Remember the last known good filter seen, so when NINA sends
+            // empty-array fields later we still have a 'previous' to show.
+            if event.event == event_types::FILTERWHEEL_CHANGED
+                && let Some(EventDetails::FilterWheelChange { new, .. }) = &event.details
+                && !new.is_unknown()
+            {
+                self.state.last_filter = Some(new.clone());
             }
 
             // Track TS-TARGETSTART events
@@ -220,9 +250,43 @@ impl ChatUpdater {
                 }
             }
 
+            // Track latest mount-state event (events are in chronological order).
+            match event.event.as_str() {
+                event_types::MOUNT_PARKED
+                | event_types::MOUNT_UNPARKED
+                | event_types::MOUNT_HOMED
+                | event_types::MOUNT_BEFORE_FLIP
+                | event_types::MOUNT_AFTER_FLIP
+                | event_types::MOUNT_CENTER => {
+                    self.state.last_mount_event = Some(event.event.clone());
+                }
+                event_types::GUIDER_START
+                | event_types::GUIDER_STOP
+                | event_types::GUIDER_DITHER => {
+                    self.state.last_guider_event = Some(event.event.clone());
+                }
+                event_types::SEQUENCE_STARTING => self.state.sequence_running = true,
+                event_types::SEQUENCE_FINISHED => self.state.sequence_running = false,
+                event_types::TS_WAITSTART => {
+                    if let Some(EventDetails::WaitStart { wait_end_time }) = &event.details
+                        && let Ok(parsed) = DateTime::parse_from_rfc3339(wait_end_time)
+                    {
+                        self.state.wait_until = Some(parsed);
+                    }
+                }
+                _ => {}
+            }
+
             self.state
                 .events_seen
                 .insert(UpdaterState::event_key(event));
+        }
+
+        // If the recorded wait has already elapsed, clear it.
+        if let Some(end) = self.state.wait_until
+            && Utc::now() >= end
+        {
+            self.state.wait_until = None;
         }
 
         // Set the latest TS target if found
@@ -250,9 +314,12 @@ impl ChatUpdater {
     }
 
     fn should_process_event(&self, event: &Event) -> bool {
-        // Skip redundant filterwheel events
+        // Skip redundant filterwheel events, but only when both filters are
+        // known — empty/unknown payloads need to be enriched, not dropped.
         if event.event == event_types::FILTERWHEEL_CHANGED
             && let Some(EventDetails::FilterWheelChange { new, previous }) = &event.details
+            && !new.is_unknown()
+            && !previous.is_unknown()
         {
             return new.name != previous.name;
         }
@@ -261,14 +328,108 @@ impl ChatUpdater {
 
     async fn handle_event(&mut self, event: &Event) {
         match event.event.as_str() {
-            event_types::TS_TARGETSTART => self.handle_ts_targetstart(event).await,
+            event_types::TS_TARGETSTART | event_types::TS_NEWTARGETSTART => {
+                self.handle_ts_targetstart(event).await
+            }
             event_types::AUTOFOCUS_FINISHED => self.handle_autofocus_finished(event).await,
+            event_types::FILTERWHEEL_CHANGED => self.handle_filterwheel_changed(event).await,
             event_types::MOUNT_BEFORE_FLIP
             | event_types::MOUNT_AFTER_FLIP
-            | event_types::MOUNT_PARKED => self.handle_mount_event(event).await,
+            | event_types::MOUNT_PARKED
+            | event_types::MOUNT_UNPARKED
+            | event_types::MOUNT_HOMED
+            | event_types::MOUNT_CENTER => self.handle_mount_event(event).await,
+            event_types::GUIDER_START | event_types::GUIDER_DITHER => {
+                self.handle_guider_event(event).await
+            }
+            event_types::SEQUENCE_STARTING | event_types::SEQUENCE_FINISHED => {
+                self.handle_sequence_event(event).await
+            }
             event_types::IMAGE_SAVE => {} // Handled in image polling
             _ => self.handle_generic_event(event).await,
         }
+    }
+
+    /// Filter wheel change events from NINA sometimes arrive with empty Name/Id
+    /// arrays. When that happens, fetch the live filterwheel state to recover
+    /// the actual current filter, and use the cached previous filter for the
+    /// 'from' side. Always update the cache after handling.
+    async fn handle_filterwheel_changed(&mut self, event: &Event) {
+        let (mut new, mut previous) =
+            if let Some(EventDetails::FilterWheelChange { new, previous }) = &event.details {
+                (new.clone(), previous.clone())
+            } else {
+                return;
+            };
+
+        if new.is_unknown() {
+            match self.client.get_filterwheel_info().await {
+                Ok(info) => {
+                    if let Some(selected) = info.response.selected_filter {
+                        new = selected;
+                    }
+                }
+                Err(e) => eprintln!("Failed to enrich filterwheel info: {e}"),
+            }
+        }
+
+        if previous.is_unknown()
+            && let Some(cached) = &self.state.last_filter
+        {
+            previous = cached.clone();
+        }
+
+        // No useful change to report (same filter, both known).
+        if !new.is_unknown() && !previous.is_unknown() && new.name == previous.name {
+            self.state.last_filter = Some(new);
+            return;
+        }
+
+        if !new.is_unknown() {
+            self.state.last_filter = Some(new.clone());
+        }
+
+        if self.chat_manager.service_count() > 0 {
+            self.send_filterwheel_change_notification(event, &previous, &new)
+                .await;
+        }
+    }
+
+    async fn send_filterwheel_change_notification(
+        &self,
+        event: &Event,
+        previous: &FilterInfo,
+        new: &FilterInfo,
+    ) {
+        let fmt = |f: &FilterInfo| {
+            if f.is_unknown() {
+                "(unknown)".to_string()
+            } else {
+                format!("{} (ID: {})", f.name, f.id)
+            }
+        };
+        let arrow = format!(
+            "{} → {}",
+            if previous.is_unknown() {
+                "(unknown)".to_string()
+            } else {
+                previous.name.clone()
+            },
+            if new.is_unknown() {
+                "(unknown)".to_string()
+            } else {
+                new.name.clone()
+            },
+        );
+
+        let message = ChatMessage::new("🔄 Filter Changed")
+            .color(colors::BLUE)
+            .field("Time", &event.time, false)
+            .field("Filter Change", &arrow, false)
+            .field("Previous", &fmt(previous), true)
+            .field("New", &fmt(new), true);
+
+        self.chat_manager.send_message(&message).await;
     }
 
     async fn handle_ts_targetstart(&mut self, event: &Event) {
@@ -334,6 +495,24 @@ impl ChatUpdater {
         if self.chat_manager.service_count() > 0 {
             self.send_mount_event_notification(event).await;
         }
+    }
+
+    async fn handle_guider_event(&self, event: &Event) {
+        if self.chat_manager.service_count() == 0 {
+            return;
+        }
+        let info = self.client.get_guider_info().await.ok();
+        self.send_guider_event_notification(event, info.as_ref())
+            .await;
+    }
+
+    async fn handle_sequence_event(&self, event: &Event) {
+        if self.chat_manager.service_count() == 0 {
+            return;
+        }
+        // Use the freshest sequence we have. The poll_sequence loop refreshes
+        // this every cycle, so it's typically <interval seconds stale.
+        self.send_sequence_event_notification(event).await;
     }
 
     async fn handle_generic_event(&self, event: &Event) {
@@ -495,6 +674,12 @@ impl ChatUpdater {
         let mut message =
             ChatMessage::new("🚀 SpaceCat Observatory Monitor Started").color(colors::GREEN);
 
+        // Inferred NINA state from event history
+        let summary = self.format_startup_status();
+        if !summary.is_empty() {
+            message = message.field("Status", &summary, false);
+        }
+
         // Add current target information
         if let Some(target) = &self.state.current_target {
             message = message.field("Current Target", &target.name, false);
@@ -524,6 +709,12 @@ impl ChatUpdater {
             message = message.field("Current Target", "None detected", false);
         }
 
+        if let Some(filter) = &self.state.last_filter
+            && !filter.is_unknown()
+        {
+            message = message.field("Last Filter", &filter.name, true);
+        }
+
         // Add baseline information
         message = message
             .field(
@@ -551,6 +742,53 @@ impl ChatUpdater {
         message = message.footer("Ready to monitor telescope events and images");
 
         self.chat_manager.send_message(&message).await;
+    }
+
+    /// Build a one-paragraph summary of NINA's state, inferred from recent events.
+    /// Includes wait timer, sequence running, mount state, guider state.
+    fn format_startup_status(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(end) = self.state.wait_until {
+            let now = Utc::now();
+            let minutes = end.with_timezone(&Utc).signed_duration_since(now).num_minutes();
+            if minutes > 0 {
+                parts.push(format!(
+                    "⏳ Waiting until {} ({} min remaining)",
+                    end.format("%H:%M %Z"),
+                    minutes
+                ));
+            }
+        }
+
+        if self.state.sequence_running {
+            parts.push("▶️ Sequence running".to_string());
+        }
+
+        if let Some(ev) = &self.state.last_mount_event {
+            let label = match ev.as_str() {
+                event_types::MOUNT_PARKED => "🅿️ Mount parked",
+                event_types::MOUNT_UNPARKED => "🔭 Mount unparked",
+                event_types::MOUNT_HOMED => "🏠 Mount homed",
+                event_types::MOUNT_BEFORE_FLIP => "🔄 Mount pre-flip",
+                event_types::MOUNT_AFTER_FLIP => "✅ Mount post-flip",
+                event_types::MOUNT_CENTER => "🎯 Mount centered",
+                _ => "🔭 Mount active",
+            };
+            parts.push(label.to_string());
+        }
+
+        if let Some(ev) = &self.state.last_guider_event {
+            let label = match ev.as_str() {
+                event_types::GUIDER_START => "🎯 Guiding",
+                event_types::GUIDER_DITHER => "🎯 Dithering",
+                event_types::GUIDER_STOP => "🛑 Guider stopped",
+                _ => "🎯 Guider active",
+            };
+            parts.push(label.to_string());
+        }
+
+        parts.join("\n")
     }
 
     async fn send_target_change_notification(
@@ -674,6 +912,9 @@ impl ChatUpdater {
             }
             event_types::MOUNT_AFTER_FLIP => ("✅ Mount Meridian Flip Completed", colors::GREEN),
             event_types::MOUNT_PARKED => ("🅿️ Mount Parked", colors::YELLOW),
+            event_types::MOUNT_UNPARKED => ("🔭 Mount Unparked", colors::YELLOW),
+            event_types::MOUNT_HOMED => ("🏠 Mount Homed", colors::CYAN),
+            event_types::MOUNT_CENTER => ("🎯 Mount Centered", colors::CYAN),
             _ => ("🔭 Mount Event", colors::GRAY),
         };
 
@@ -687,6 +928,91 @@ impl ChatUpdater {
         }
 
         self.add_mount_info(&mut message).await;
+        self.chat_manager.send_message(&message).await;
+    }
+
+    async fn send_guider_event_notification(
+        &self,
+        event: &Event,
+        info: Option<&crate::guider::GuiderInfoResponse>,
+    ) {
+        let (title, color) = match event.event.as_str() {
+            event_types::GUIDER_START => ("🎯 Guiding Started", colors::BLUE),
+            event_types::GUIDER_DITHER => ("🎯 Guider Dither", colors::CYAN),
+            _ => ("🎯 Guider Event", colors::GRAY),
+        };
+
+        let mut message = ChatMessage::new(title)
+            .color(color)
+            .field("Event", &event.event, true)
+            .field("Time", &event.time, true);
+
+        if let Some(target) = &self.state.current_target {
+            message = message.field("Current Target", &target.name, true);
+        }
+
+        if let Some(info) = info
+            && info.response.connected
+        {
+            let g = &info.response;
+            message = message.field("State", &g.state, true);
+            if g.pixel_scale > 0.0 {
+                message =
+                    message.field("Pixel Scale", &format!("{:.3} arcsec/px", g.pixel_scale), true);
+            }
+            if let Some(rms) = &g.rms_error {
+                message = message.field(
+                    "RMS Error",
+                    &format!(
+                        "Total: {:.2}\"\nRA: {:.2}\"  Dec: {:.2}\"",
+                        rms.total.arcseconds, rms.ra.arcseconds, rms.dec.arcseconds
+                    ),
+                    false,
+                );
+            }
+        }
+
+        self.chat_manager.send_message(&message).await;
+    }
+
+    async fn send_sequence_event_notification(&self, event: &Event) {
+        let (title, color) = match event.event.as_str() {
+            event_types::SEQUENCE_STARTING => ("▶️ Sequence Starting", colors::CYAN),
+            event_types::SEQUENCE_FINISHED => ("🏁 Sequence Finished", colors::GREEN),
+            _ => ("📋 Sequence Event", colors::GRAY),
+        };
+
+        let mut message = ChatMessage::new(title)
+            .color(color)
+            .field("Event", &event.event, true)
+            .field("Time", &event.time, true);
+
+        if let Some(target) = &self.state.current_target {
+            message = message.field("Current Target", &target.name, true);
+            if let Some(coords) = &target.coordinates {
+                message = message.field(
+                    "Coordinates",
+                    &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
+                    false,
+                );
+            }
+        }
+
+        if let Some(seq) = &self.state.sequence {
+            let containers = seq.get_containers();
+            if !containers.is_empty() {
+                let running = containers
+                    .iter()
+                    .filter(|c| c.status.eq_ignore_ascii_case("RUNNING"))
+                    .count();
+                message = message.field(
+                    "Containers",
+                    &format!("{} total / {} running", containers.len(), running),
+                    true,
+                );
+            }
+        }
+
         self.chat_manager.send_message(&message).await;
     }
 
@@ -718,6 +1044,9 @@ impl ChatUpdater {
                 EventDetails::TargetStart { .. } => {
                     // Already handled in handle_ts_targetstart
                     return;
+                }
+                EventDetails::WaitStart { wait_end_time } => {
+                    message = message.field("Wait Until", wait_end_time, false);
                 }
             }
         }
@@ -859,38 +1188,35 @@ fn get_event_color(event: &str) -> u32 {
         event_types::MOUNT_DISCONNECTED => colors::RED,
         event_types::MOUNT_PARKED => colors::YELLOW,
         event_types::MOUNT_UNPARKED => colors::YELLOW,
-        event_types::MOUNT_SLEW => colors::ORANGE,
+        event_types::MOUNT_HOMED => colors::CYAN,
+        event_types::MOUNT_CENTER => colors::CYAN,
 
         // Focuser events
         event_types::FOCUSER_CONNECTED => colors::GREEN,
         event_types::FOCUSER_DISCONNECTED => colors::RED,
-        event_types::FOCUS_START => colors::PURPLE,
-        event_types::FOCUS_END => colors::PURPLE,
+        event_types::FOCUSER_USER_FOCUSED => colors::PURPLE,
+        event_types::AUTOFOCUS_STARTING => colors::PURPLE,
         event_types::AUTOFOCUS_FINISHED => colors::PURPLE,
+        event_types::ERROR_AF => colors::RED,
 
         // Rotator events
         event_types::ROTATOR_CONNECTED => colors::GREEN,
         event_types::ROTATOR_DISCONNECTED => colors::RED,
         event_types::ROTATOR_MOVED => colors::CYAN,
+        event_types::ROTATOR_MOVED_MECHANICAL => colors::CYAN,
         event_types::ROTATOR_SYNCED => colors::CYAN,
 
         // Guider events
         event_types::GUIDER_CONNECTED => colors::GREEN,
         event_types::GUIDER_DISCONNECTED => colors::RED,
         event_types::GUIDER_START => colors::BLUE,
+        event_types::GUIDER_STOP => colors::YELLOW,
         event_types::GUIDER_DITHER => colors::CYAN,
 
         // Sequence events
-        event_types::SEQUENCE_START => colors::CYAN,
-        event_types::SEQUENCE_STOP => colors::ORANGE,
-        event_types::SEQUENCE_PAUSE => colors::YELLOW,
-        event_types::SEQUENCE_RESUME => colors::CYAN,
+        event_types::SEQUENCE_STARTING => colors::CYAN,
         event_types::SEQUENCE_FINISHED => colors::GREEN,
-        event_types::ADV_SEQ_STOP => colors::ORANGE,
-
-        // Exposure events
-        event_types::EXPOSURE_START => colors::YELLOW,
-        event_types::EXPOSURE_END => colors::GREEN,
+        event_types::SEQUENCE_ENTITY_FAILED => colors::RED,
 
         // System events
         event_types::FLAT_DISCONNECTED
@@ -898,9 +1224,17 @@ fn get_event_color(event: &str) -> u32 {
         | event_types::SWITCH_DISCONNECTED
         | event_types::DOME_DISCONNECTED
         | event_types::SAFETY_DISCONNECTED => colors::RED,
+        event_types::FLAT_CONNECTED
+        | event_types::WEATHER_CONNECTED
+        | event_types::SWITCH_CONNECTED
+        | event_types::SAFETY_CONNECTED => colors::GREEN,
+        event_types::SAFETY_CHANGED => colors::ORANGE,
+        event_types::CAMERA_DOWNLOAD_TIMEOUT => colors::RED,
+        event_types::ERROR_PLATESOLVE => colors::RED,
 
         // Target events
-        event_types::TS_TARGETSTART => colors::CYAN,
+        event_types::TS_TARGETSTART | event_types::TS_NEWTARGETSTART => colors::CYAN,
+        event_types::TS_WAITSTART => colors::YELLOW,
 
         // Fallback patterns
         _ if event.contains("ERROR") => colors::RED,
@@ -913,6 +1247,7 @@ fn get_event_title(event: &str) -> String {
     match event {
         event_types::FILTERWHEEL_CHANGED => "🔄 Filter Changed".to_string(),
         event_types::TS_TARGETSTART => "🎯 Target Started".to_string(),
+        event_types::TS_WAITSTART => "⏳ Sequence Waiting".to_string(),
         _ => format!("📡 {}", event),
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -41,13 +41,54 @@ pub enum EventDetails {
         #[serde(rename = "Coordinates")]
         coordinates: TargetCoordinates,
     },
+    WaitStart {
+        #[serde(rename = "WaitEndTime")]
+        wait_end_time: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct FilterInfo {
+    // NINA occasionally returns Name:[] / Id:[] (empty arrays) when the slot is unknown.
+    // Accept that shape and fall back to empty/-1 sentinels.
+    #[serde(deserialize_with = "de_filter_name")]
     pub name: String,
+    #[serde(deserialize_with = "de_filter_id")]
     pub id: i32,
+}
+
+impl FilterInfo {
+    pub fn is_unknown(&self) -> bool {
+        self.name.is_empty() || self.id < 0
+    }
+}
+
+fn de_filter_name<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Array(a) if a.is_empty() => Ok(String::new()),
+        other => Err(D::Error::custom(format!(
+            "expected string or [] for filter name, got {other}"
+        ))),
+    }
+}
+
+fn de_filter_id<'de, D: Deserializer<'de>>(d: D) -> Result<i32, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .ok_or_else(|| D::Error::custom("filter id is not an integer"))
+            .map(|x| x as i32),
+        serde_json::Value::Array(a) if a.is_empty() => Ok(-1),
+        other => Err(D::Error::custom(format!(
+            "expected integer or [] for filter id, got {other}"
+        ))),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -64,10 +105,13 @@ pub struct TargetCoordinates {
     pub ra_degrees: f64,
 }
 
-// Event type constants for easier matching
+// Event type constants for easier matching.
+// Source of truth: ninaAPI source (christian-photo/ninaAPI). Only events actually
+// emitted by NINA appear here.
 pub mod event_types {
     pub const CAMERA_DISCONNECTED: &str = "CAMERA-DISCONNECTED";
     pub const CAMERA_CONNECTED: &str = "CAMERA-CONNECTED";
+    pub const CAMERA_DOWNLOAD_TIMEOUT: &str = "CAMERA-DOWNLOAD-TIMEOUT";
     pub const FILTERWHEEL_DISCONNECTED: &str = "FILTERWHEEL-DISCONNECTED";
     pub const FILTERWHEEL_CONNECTED: &str = "FILTERWHEEL-CONNECTED";
     pub const FILTERWHEEL_CHANGED: &str = "FILTERWHEEL-CHANGED";
@@ -77,36 +121,45 @@ pub mod event_types {
     pub const MOUNT_PARKED: &str = "MOUNT-PARKED";
     pub const MOUNT_BEFORE_FLIP: &str = "MOUNT-BEFORE-FLIP";
     pub const MOUNT_AFTER_FLIP: &str = "MOUNT-AFTER-FLIP";
+    pub const MOUNT_HOMED: &str = "MOUNT-HOMED";
+    pub const MOUNT_CENTER: &str = "MOUNT-CENTER";
     pub const FOCUSER_DISCONNECTED: &str = "FOCUSER-DISCONNECTED";
     pub const FOCUSER_CONNECTED: &str = "FOCUSER-CONNECTED";
+    pub const FOCUSER_USER_FOCUSED: &str = "FOCUSER-USER-FOCUSED";
     pub const ROTATOR_DISCONNECTED: &str = "ROTATOR-DISCONNECTED";
     pub const ROTATOR_CONNECTED: &str = "ROTATOR-CONNECTED";
+    pub const ROTATOR_MOVED: &str = "ROTATOR-MOVED";
+    pub const ROTATOR_MOVED_MECHANICAL: &str = "ROTATOR-MOVED-MECHANICAL";
+    pub const ROTATOR_SYNCED: &str = "ROTATOR-SYNCED";
     pub const GUIDER_CONNECTED: &str = "GUIDER-CONNECTED";
     pub const GUIDER_DISCONNECTED: &str = "GUIDER-DISCONNECTED";
     pub const GUIDER_START: &str = "GUIDER-START";
+    pub const GUIDER_STOP: &str = "GUIDER-STOP";
     pub const GUIDER_DITHER: &str = "GUIDER-DITHER";
-    pub const ROTATOR_MOVED: &str = "ROTATOR-MOVED";
-    pub const ROTATOR_SYNCED: &str = "ROTATOR-SYNCED";
+    pub const FLAT_CONNECTED: &str = "FLAT-CONNECTED";
     pub const FLAT_DISCONNECTED: &str = "FLAT-DISCONNECTED";
+    pub const WEATHER_CONNECTED: &str = "WEATHER-CONNECTED";
     pub const WEATHER_DISCONNECTED: &str = "WEATHER-DISCONNECTED";
+    pub const SWITCH_CONNECTED: &str = "SWITCH-CONNECTED";
     pub const SWITCH_DISCONNECTED: &str = "SWITCH-DISCONNECTED";
     pub const DOME_DISCONNECTED: &str = "DOME-DISCONNECTED";
+    pub const SAFETY_CONNECTED: &str = "SAFETY-CONNECTED";
     pub const SAFETY_DISCONNECTED: &str = "SAFETY-DISCONNECTED";
+    pub const SAFETY_CHANGED: &str = "SAFETY-CHANGED";
     pub const IMAGE_SAVE: &str = "IMAGE-SAVE";
+    pub const IMAGE_PREPARED: &str = "IMAGE-PREPARED";
+    pub const API_CAPTURE_FINISHED: &str = "API-CAPTURE-FINISHED";
+    pub const AUTOFOCUS_STARTING: &str = "AUTOFOCUS-STARTING";
     pub const AUTOFOCUS_FINISHED: &str = "AUTOFOCUS-FINISHED";
-    pub const SEQUENCE_START: &str = "SEQUENCE-START";
-    pub const SEQUENCE_STOP: &str = "SEQUENCE-STOP";
-    pub const SEQUENCE_PAUSE: &str = "SEQUENCE-PAUSE";
-    pub const SEQUENCE_RESUME: &str = "SEQUENCE-RESUME";
+    pub const AUTOFOCUS_POINT_ADDED: &str = "AUTOFOCUS-POINT-ADDED";
+    pub const ERROR_AF: &str = "ERROR-AF";
+    pub const ERROR_PLATESOLVE: &str = "ERROR-PLATESOLVE";
+    pub const SEQUENCE_STARTING: &str = "SEQUENCE-STARTING";
     pub const SEQUENCE_FINISHED: &str = "SEQUENCE-FINISHED";
-    pub const EXPOSURE_START: &str = "EXPOSURE-START";
-    pub const EXPOSURE_END: &str = "EXPOSURE-END";
-    pub const MOUNT_SLEW: &str = "MOUNT-SLEW";
-    pub const FOCUS_START: &str = "FOCUS-START";
-    pub const FOCUS_END: &str = "FOCUS-END";
-    pub const ADV_SEQ_STOP: &str = "ADV-SEQ-STOP";
-    pub const FOCUSER_USER_FOCUSED: &str = "FOCUSER-USER-FOCUSED";
+    pub const SEQUENCE_ENTITY_FAILED: &str = "SEQUENCE-ENTITY-FAILED";
     pub const TS_TARGETSTART: &str = "TS-TARGETSTART";
+    pub const TS_NEWTARGETSTART: &str = "TS-NEWTARGETSTART";
+    pub const TS_WAITSTART: &str = "TS-WAITSTART";
 }
 
 impl EventHistoryResponse {
@@ -352,6 +405,44 @@ mod tests {
             assert_eq!(coordinates.ra_degrees, 312.34166666666664);
         } else {
             panic!("Expected TargetStart details");
+        }
+    }
+
+    #[test]
+    fn test_filterwheel_change_empty_arrays() {
+        // NINA can return Name:[] / Id:[] when the wheel slot is unknown.
+        let event_json = r#"{
+            "Time": "2026-05-18T20:12:14.1465888-07:00",
+            "Previous": {"Name": [], "Id": []},
+            "New": {"Name": [], "Id": []},
+            "Event": "FILTERWHEEL-CHANGED"
+        }"#;
+        let event: Event = serde_json::from_str(event_json).unwrap();
+        match event.details {
+            Some(EventDetails::FilterWheelChange { new, previous }) => {
+                assert!(new.is_unknown());
+                assert!(previous.is_unknown());
+                assert_eq!(new.name, "");
+                assert_eq!(new.id, -1);
+            }
+            other => panic!("expected FilterWheelChange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_ts_waitstart_event() {
+        let event_json = r#"{
+            "WaitEndTime": "2026-05-18T22:02:21.3561448-07:00",
+            "Time": "2026-05-19T03:20:43.4843722",
+            "Event": "TS-WAITSTART"
+        }"#;
+        let event: Event = serde_json::from_str(event_json).unwrap();
+        assert_eq!(event.event, event_types::TS_WAITSTART);
+        match event.details {
+            Some(EventDetails::WaitStart { wait_end_time }) => {
+                assert_eq!(wait_end_time, "2026-05-18T22:02:21.3561448-07:00");
+            }
+            other => panic!("expected WaitStart, got {other:?}"),
         }
     }
 

--- a/src/filterwheel.rs
+++ b/src/filterwheel.rs
@@ -1,0 +1,54 @@
+use crate::events::FilterInfo;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct FilterWheelInfoResponse {
+    pub response: FilterWheelInfo,
+    pub error: String,
+    pub status_code: i32,
+    pub success: bool,
+    #[serde(rename = "Type")]
+    pub response_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct FilterWheelInfo {
+    pub connected: bool,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub is_moving: bool,
+    pub selected_filter: Option<FilterInfo>,
+    #[serde(default)]
+    pub available_filters: Vec<FilterInfo>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_live_filterwheel_info() {
+        let json = r#"{"Response":{"Connected":true,"Name":"EFW","DisplayName":"EFW","Description":"Native driver for ZWOptical filter wheels","DriverInfo":"SDK: 1, 7; FW: 4.0.4","DriverVersion":"1.0","DeviceId":"ZWOptical_EFW_","SupportedActions":[],"IsMoving":false,"SelectedFilter":{"Name":"B","Id":5},"AvailableFilters":[{"Name":"HA","Id":0},{"Name":"OIII","Id":1},{"Name":"SII","Id":2},{"Name":"R","Id":3},{"Name":"G","Id":4},{"Name":"B","Id":5},{"Name":"L","Id":6}]},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: FilterWheelInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.success);
+        assert!(parsed.response.connected);
+        let selected = parsed.response.selected_filter.unwrap();
+        assert_eq!(selected.name, "B");
+        assert_eq!(selected.id, 5);
+        assert_eq!(parsed.response.available_filters.len(), 7);
+        assert_eq!(parsed.response.available_filters[0].name, "HA");
+    }
+
+    #[test]
+    fn test_parse_disconnected_filterwheel() {
+        let json = r#"{"Response":{"Connected":false,"Name":"","DisplayName":"","IsMoving":false,"SelectedFilter":null,"AvailableFilters":[]},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: FilterWheelInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(!parsed.response.connected);
+        assert!(parsed.response.selected_filter.is_none());
+    }
+}

--- a/src/guider.rs
+++ b/src/guider.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GuiderInfoResponse {
+    pub response: GuiderInfo,
+    pub error: String,
+    pub status_code: i32,
+    pub success: bool,
+    #[serde(rename = "Type")]
+    pub response_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GuiderInfo {
+    pub connected: bool,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub pixel_scale: f64,
+    #[serde(rename = "RMSError", default)]
+    pub rms_error: Option<GuiderRmsError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuiderRmsError {
+    #[serde(rename = "RA")]
+    pub ra: GuiderAxisError,
+    #[serde(rename = "Dec")]
+    pub dec: GuiderAxisError,
+    #[serde(rename = "Total")]
+    pub total: GuiderAxisError,
+    #[serde(rename = "PeakRA", default)]
+    pub peak_ra: Option<GuiderAxisError>,
+    #[serde(rename = "PeakDec", default)]
+    pub peak_dec: Option<GuiderAxisError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct GuiderAxisError {
+    pub pixel: f64,
+    pub arcseconds: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_live_guider_info() {
+        let json = r#"{"Response":{"Connected":true,"Name":"PHD2","DisplayName":"PHD2","Description":"PHD2 Guider","DriverInfo":"PHD2 Guider","DriverVersion":"1.0","DeviceId":"PHD2_Single","CanClearCalibration":true,"CanSetShiftRate":true,"CanGetLockPosition":true,"SupportedActions":[],"RMSError":{"RA":{"Pixel":0,"Arcseconds":0},"Dec":{"Pixel":0,"Arcseconds":0},"Total":{"Pixel":0,"Arcseconds":0},"PeakRA":{"Pixel":0,"Arcseconds":0},"PeakDec":{"Pixel":0,"Arcseconds":0}},"PixelScale":0.351089,"State":"Stopped"},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: GuiderInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.success);
+        assert!(parsed.response.connected);
+        assert_eq!(parsed.response.state, "Stopped");
+        assert!((parsed.response.pixel_scale - 0.351089).abs() < 1e-6);
+        let rms = parsed.response.rms_error.unwrap();
+        assert_eq!(rms.total.arcseconds, 0.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod config;
 pub mod discord;
 pub mod error;
 pub mod events;
+pub mod filterwheel;
+pub mod guider;
 pub mod images;
 pub mod mount;
 pub mod poller;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 #[command(about = "SpaceCat - Astronomical Observation System", long_about = None)]
 struct Cli {
     /// Path to configuration file
-    #[arg(short, long, default_value = "config.json", global = true)]
+    #[arg(long, default_value = "config.json", global = true)]
     config: String,
 
     #[command(subcommand)]
@@ -1117,6 +1117,9 @@ fn display_last_events(events: &EventHistoryResponse, count: usize) {
                     );
                     println!("    Rotation: {}°", rotation);
                 }
+                EventDetails::WaitStart { wait_end_time } => {
+                    println!("  Details: Waiting until {}", wait_end_time);
+                }
             }
         }
 
@@ -1133,18 +1136,25 @@ fn get_event_type_info(event_name: &str) -> (&'static str, &'static str) {
 
     match event_name {
         event_types::IMAGE_SAVE => ("📸", "Image captured and saved"),
+        event_types::IMAGE_PREPARED => ("🖼️", "Image prepared"),
+        event_types::API_CAPTURE_FINISHED => ("📷", "API capture finished"),
         event_types::FILTERWHEEL_CHANGED => ("🔄", "Filter wheel position changed"),
+        event_types::GUIDER_START => ("🎯", "Guiding started"),
+        event_types::GUIDER_STOP => ("🛑", "Guiding stopped"),
         event_types::GUIDER_DITHER => ("🎯", "Dithering for drizzling"),
-        event_types::SEQUENCE_START => ("▶️", "Sequence started"),
-        event_types::SEQUENCE_STOP => ("⏹️", "Sequence stopped"),
-        event_types::SEQUENCE_PAUSE => ("⏸️", "Sequence paused"),
-        event_types::SEQUENCE_RESUME => ("▶️", "Sequence resumed"),
-        event_types::EXPOSURE_START => ("🌟", "Exposure started"),
-        event_types::EXPOSURE_END => ("✨", "Exposure completed"),
-        event_types::MOUNT_SLEW => ("🔭", "Mount slewing to target"),
-        event_types::FOCUS_START => ("🔍", "Auto-focus started"),
-        event_types::FOCUS_END => ("✅", "Auto-focus completed"),
-        event_types::TS_TARGETSTART => ("🎯", "Target started"),
+        event_types::SEQUENCE_STARTING => ("▶️", "Sequence starting"),
+        event_types::SEQUENCE_FINISHED => ("🏁", "Sequence finished"),
+        event_types::SEQUENCE_ENTITY_FAILED => ("❌", "Sequence entity failed"),
+        event_types::MOUNT_HOMED => ("🏠", "Mount homed"),
+        event_types::MOUNT_CENTER => ("🎯", "Mount centered"),
+        event_types::AUTOFOCUS_STARTING => ("🔍", "Auto-focus starting"),
+        event_types::AUTOFOCUS_FINISHED => ("✅", "Auto-focus finished"),
+        event_types::AUTOFOCUS_POINT_ADDED => ("📈", "Auto-focus point added"),
+        event_types::ERROR_AF => ("⚠️", "Auto-focus error"),
+        event_types::ERROR_PLATESOLVE => ("⚠️", "Plate-solve error"),
+        event_types::CAMERA_DOWNLOAD_TIMEOUT => ("⏱️", "Camera download timeout"),
+        event_types::TS_TARGETSTART | event_types::TS_NEWTARGETSTART => ("🎯", "Target started"),
+        event_types::TS_WAITSTART => ("⏳", "Sequence waiting"),
         _ => ("📋", "System event"),
     }
 }


### PR DESCRIPTION
## Summary

- Tolerate NINA's degraded payloads (empty-array `FilterInfo`, new `TS-WAITSTART` event) so chat updater no longer silently drops detail.
- Add API-callback enrichment hooks for `FILTERWHEEL-CHANGED`, `GUIDER-START`/`-DITHER`, `SEQUENCE-STARTING`/`-FINISHED`, and additional mount lifecycle events — mirroring the existing `AUTOFOCUS-FINISHED` pattern.
- Infer NINA's current state (active wait timer with minutes-remaining, mount park status, guider state, sequence-running, last filter) by walking baseline event history; render it in both stdout and the Discord/Matrix welcome message.
- Reconcile `event_types` constants against the actual ninaAPI source: drop events NINA never emits (`MOUNT_SLEW`, `EXPOSURE_*`, `FOCUS_START`/`END`, `SEQUENCE_START`/`STOP`/`PAUSE`/`RESUME`, `ADV_SEQ_STOP`); add real ones (`MOUNT_HOMED`, `AUTOFOCUS_STARTING`/`POINT_ADDED`, `GUIDER_STOP`, `SEQUENCE_STARTING`/`ENTITY_FAILED`, `API_CAPTURE_FINISHED`, ...).
- Fix `last-events` crash: clap panicked on startup because the global `--config` short `-c` collided with `--count -c`. Removed the global short.
- Add `config.*.json` to `.gitignore` so per-rig configs (with webhook URLs / matrix passwords) can't be committed by accident.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 37 lib tests + 4 integration tests pass (added unit tests for empty-array FilterInfo, TS-WAITSTART, filterwheel/info parse, guider/info parse)
- [x] `cargo clippy` clean
- [x] Live API smoke test against `c925` rig: `cargo run -- --config config.c925.json last-events --count 20` parses FILTERWHEEL-CHANGED (empty Name/Id) and TS-WAITSTART correctly
- [x] Live `chat-updater` startup shows inferred state: `⏳ Waiting until 22:02 -07:00 (69 min remaining)` + `🔭 Mount unparked`
- [ ] Observe a real FILTERWHEEL-CHANGED in production to confirm enrichment via `/equipment/filterwheel/info`
- [ ] Observe a real GUIDER-START / DITHER to confirm guider info embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)