### PR TITLE
discord: bot with read commands, live status, write commands (phases 1–3)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration.
+#
+# Advisories listed under `ignore` are silenced when CI runs
+# `cargo audit`. Each entry must include a short comment explaining
+# *why* it's tolerated and the condition under which it can be removed.
+
+[advisories]
+ignore = [
+    # rustls-webpki 0.102.8 (pulled in by serenity 0.12 → tokio-tungstenite
+    # 0.21 → rustls 0.22 → rustls-webpki 0.102.x for the Discord gateway
+    # websocket). All fixes are in 0.103.x, which requires rustls 0.23+,
+    # which requires tokio-tungstenite 0.23+, which serenity 0.12 doesn't
+    # use. The HTTP path (reqwest / matrix-sdk / our NINA client) uses
+    # modern rustls 0.23 / rustls-webpki 0.103.13 — unaffected.
+    #
+    # The advisories cover CRL parsing and name-constraint validation on
+    # the cert path we use for one well-known endpoint (gateway.discord.gg),
+    # signed by a major public CA — these CVEs aren't reachable in our
+    # threat model.
+    #
+    # Drop these once serenity ships a release that uses tokio-tungstenite
+    # ≥ 0.23 (tracked upstream — serenity issue tracker).
+    "RUSTSEC-2026-0049",
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 config.json
 config.*.json
+spacecat-state.json
 *.log
 /installer/output
 .vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +373,37 @@ name = "bytesize"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cbc"
@@ -633,6 +670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +731,61 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "serde",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "date_header"
@@ -758,6 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -899,6 +1001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,12 +1136,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1150,6 +1276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1336,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1338,11 +1476,12 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1481,6 +1620,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1914,9 +2059,9 @@ dependencies = [
  "oauth2-reqwest",
  "percent-encoding",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.13.3",
  "ruma",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -1932,7 +2077,7 @@ dependencies = [
  "url",
  "urlencoding",
  "vodozemac",
- "webpki-roots",
+ "webpki-roots 1.0.7",
  "zeroize",
 ]
 
@@ -2178,6 +2323,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,7 +2424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
 dependencies = [
  "oauth2",
- "reqwest",
+ "reqwest 0.13.3",
 ]
 
 [[package]]
@@ -2397,6 +2557,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poise"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711433114bca9ff68582aa58af5cbcf573e83250a8714c2dca1c36f453cad3ae"
+dependencies = [
+ "async-trait",
+ "derivative",
+ "futures-util",
+ "indexmap",
+ "parking_lot",
+ "regex",
+ "serenity",
+ "serenity_poise_macros",
+ "tokio",
+ "tracing",
+ "trim-in-place",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2690,17 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
@@ -2539,7 +2729,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -2560,7 +2750,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2744,6 +2934,48 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2767,7 +2999,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -2775,7 +3007,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2783,7 +3015,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2903,7 +3135,7 @@ dependencies = [
  "indexmap",
  "js_int",
  "js_option",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.3",
  "ruma-common",
  "ruma-macros",
  "serde",
@@ -2998,6 +3230,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -3005,8 +3251,9 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3044,10 +3291,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3059,6 +3306,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -3120,6 +3378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3415,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3186,6 +3458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3258,6 +3539,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "serenity"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "base64",
+ "bitflags",
+ "bytes",
+ "chrono",
+ "dashmap",
+ "flate2",
+ "futures",
+ "mime_guess",
+ "parking_lot",
+ "percent-encoding",
+ "reqwest 0.12.28",
+ "rustc-hash",
+ "secrecy",
+ "serde",
+ "serde_cow",
+ "serde_json",
+ "time",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "typemap_rev",
+ "typesize",
+ "url",
+]
+
+[[package]]
+name = "serenity_poise_macros"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc8407893be0d973a7bb48325e10e0160a0db44f4099467c83179688220e5f5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3652,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark 0.9.6",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3350,9 +3702,11 @@ dependencies = [
  "libsqlite3-sys",
  "matrix-sdk",
  "mime",
- "reqwest",
+ "poise",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
+ "serenity",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -3476,12 +3830,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3632,11 +3993,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -3650,6 +4022,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3764,6 +4152,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3803,16 +4192,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typemap_rev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typesize"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da66c62c5b7017a2787e77373c03e6a5aafde77a73bff1ff96e91cd2e128179"
+dependencies = [
+ "chrono",
+ "dashmap",
+ "hashbrown 0.14.5",
+ "mini-moka",
+ "parking_lot",
+ "secrecy",
+ "serde_json",
+ "time",
+ "typesize-derive",
+ "url",
+]
+
+[[package]]
+name = "typesize-derive"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536b6812192bda8551cfa0e52524e328c6a951b48e66529ee4522d6c721243d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "typewit"
@@ -4086,6 +4543,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4167,6 +4637,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -245,9 +245,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -290,9 +290,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -305,9 +305,9 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -416,21 +416,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -571,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -582,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1082,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1320,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1354,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1469,15 +1463,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls 0.23.40",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1640,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1704,12 +1697,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1729,16 +1722,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1772,27 +1755,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1826,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1884,9 +1872,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2375,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2408,7 +2396,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -2552,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poise"
@@ -2747,7 +2735,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.40",
@@ -2770,7 +2758,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2796,9 +2784,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2807,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3272,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3282,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3646,10 +3634,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skeptic"
@@ -4077,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -4113,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -4125,13 +4129,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4221,7 +4225,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
  "sha1",
@@ -4238,9 +4242,9 @@ checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typesize"
@@ -4273,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "typewit"
-version = "1.15.0"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fee3a8df48c50c55ad646a4e03b00a370da6fe1850ebf467a8d0165dfcafae"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ulid"
@@ -4283,7 +4287,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -4369,9 +4373,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4410,7 +4414,7 @@ dependencies = [
  "hmac",
  "matrix-pickle",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -4448,11 +4452,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4461,14 +4465,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4479,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4489,9 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4499,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4512,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4599,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4632,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4783,15 +4787,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4801,11 +4796,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4819,21 +4814,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -4841,7 +4821,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -4849,10 +4829,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+name = "windows-targets"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4861,10 +4852,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4873,10 +4864,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
+name = "windows_aarch64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4885,16 +4876,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
+name = "windows_i686_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4903,10 +4900,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
+name = "windows_i686_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4915,10 +4912,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+name = "windows_x86_64_gnu"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4927,10 +4924,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4939,10 +4936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "1.0.1"
+name = "windows_x86_64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4955,6 +4958,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5104,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ url = "2.5"
 async-trait = "0.1"
 mime = "0.3"
 thiserror = "2.0"
-# Discord bot stack. `client`/`gateway`/`rustls_backend` covers our needs;
-# voice and native-tls features intentionally omitted.
+# Discord bot stack. Note: serenity 0.12 pins tokio-tungstenite 0.21
+# → rustls 0.22 → an old rustls-webpki line. The associated RUSTSEC
+# advisories (-0049/-0098/-0099/-0104) are ignored in `.cargo/audit.toml`
+# until serenity ships against a newer tokio-tungstenite. The HTTP path
+# (reqwest 0.13 / matrix-sdk / our NINA client) uses modern rustls 0.23.
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache", "http", "builder", "utils"] }
 poise = "0.6"
 # SQLite bundled to avoid libsqlite3 dependency issues on Windows CI/releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ url = "2.5"
 async-trait = "0.1"
 mime = "0.3"
 thiserror = "2.0"
+# Discord bot stack. `client`/`gateway`/`rustls_backend` covers our needs;
+# voice and native-tls features intentionally omitted.
+serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache", "http", "builder", "utils"] }
+poise = "0.6"
 # SQLite bundled to avoid libsqlite3 dependency issues on Windows CI/releases
 libsqlite3-sys = { version = "0", features = ["bundled"] }
 

--- a/DISCORD_BOT_PLAN.md
+++ b/DISCORD_BOT_PLAN.md
@@ -1,0 +1,274 @@
+# Discord Bot — Feature Plan
+
+Add a process-wide Serenity/Poise Discord bot alongside the existing webhook
+posting model. Each telescope can map to a Discord channel; slash commands
+invoked in that channel act on the telescope's NINA API. Webhook posting
+stays untouched for setups that don't enable the bot.
+
+## Goals
+
+- **One bot, many telescopes** — single Discord application token shared
+  across all configured telescopes, mirroring the shared-Matrix model.
+- **Channel-driven defaults** — `/status` invoked in `#c925` automatically
+  targets the c925 telescope. Falls back to an explicit `--telescope` arg
+  when run from an unmapped channel.
+- **Coexist with webhooks** — bot is opt-in per telescope. If a telescope
+  configures `discord_channel_id`, the bot takes precedence; otherwise the
+  existing webhook path is used unchanged.
+- **Phased delivery** — read-only commands first; live status; write
+  commands; cosmetic polish.
+
+## Architecture
+
+### Service layer
+
+A new `DiscordBotService` implements the existing `ChatService` trait so it
+slots into `ChatServiceManager` next to `DiscordChatService` and
+`MatrixChatService`. Routing precedence is enforced via each service's
+`can_route(&ChatTarget)`:
+
+```rust
+// Webhook service: defers when a channel_id is configured.
+impl ChatService for DiscordChatService {
+    fn can_route(&self, target: &ChatTarget) -> bool {
+        if target.discord_channel_id.is_some() {
+            return false;
+        }
+        self.resolve_url(target).is_some()
+    }
+}
+
+// Bot service: takes routes that have a channel (override or default).
+impl ChatService for DiscordBotService {
+    fn can_route(&self, target: &ChatTarget) -> bool {
+        target.discord_channel_id.is_some() || self.default_channel_id.is_some()
+    }
+}
+```
+
+This keeps the routing decision local to each service — no cross-service
+knowledge.
+
+### Bot internals
+
+A single `serenity::Client` runs in a dedicated tokio task, constructed in
+`service_wrapper::build_shared_chat_manager`. The gateway connection handles
+slash commands; outbound posts (from the `ChatService::send_message` path)
+use a cloned `Arc<Http>` directly, with no mpsc bridge needed.
+
+The Poise `Data` struct carries:
+
+```rust
+pub struct BotData {
+    pub api_clients: HashMap<String, SpaceCatApiClient>,  // telescope -> client
+    pub channel_to_telescope: HashMap<ChannelId, String>,
+    pub write_acl: HashSet<UserId>,                       // Phase 3
+    pub status_state: Arc<Mutex<StatusState>>,            // Phase 2
+}
+```
+
+Gateway intents required: `GUILDS` only. We don't need `MESSAGE_CONTENT` —
+slash commands deliver parameters directly to the bot without parsing
+message bodies.
+
+## Config shape
+
+```jsonc
+{
+  "chat": {
+    "discord_bot": {
+      "enabled": true,
+      "token": "BOT_TOKEN_HERE",
+      "default_channel_id": "111111111111111111",  // optional fallback
+      "state_file": "./spacecat-state.json",       // CWD by default
+      "write_acl": ["123456789012345678"]          // Phase 3
+    },
+    "discord": { "enabled": true, "default_webhook_url": "..." },  // unchanged
+    "matrix":  { ... }  // unchanged
+  },
+  "telescopes": [
+    {
+      "name": "c925",
+      "api": { "base_url": "http://192.168.0.81:1888" },
+      "chat": {
+        "discord_channel_id": "222222222222222222"
+        // discord_webhook_url ignored when channel_id is set
+      }
+    }
+  ]
+}
+```
+
+Validation rules added to `Config::validate`:
+
+- If any telescope sets `discord_channel_id`, `chat.discord_bot.enabled`
+  must be true.
+- If `chat.discord_bot.enabled`, `token` must be non-empty.
+- Telescopes with both `discord_channel_id` and `discord_webhook_url` get a
+  startup warning ("webhook ignored — bot takes precedence") but are not
+  an error.
+
+## File / module changes
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | add `serenity = "0.12"`, `poise = "0.6"` |
+| `src/chat/discord_bot.rs` (new) | `DiscordBotService`, command framework, channel routing |
+| `src/chat/mod.rs` | export `DiscordBotService`; `ChatTarget` gains `discord_channel_id` field |
+| `src/chat/discord_service.rs` | `can_route` updated to defer when channel_id present |
+| `src/config.rs` | new `DiscordBotConfig` struct; `TelescopeChatOverrides` gains `discord_channel_id`; validation rules |
+| `src/service_wrapper.rs` | in `build_shared_chat_manager`, instantiate bot if enabled; pass `BotData` derived from telescope list |
+| `src/chat_updater.rs` | no change — already routes through `ChatTarget` |
+
+## Phasing
+
+### Phase 1 — bot infrastructure + read commands
+
+Ship the bot connected, channel-routed, registering and serving the
+following read-only slash commands. All commands accept an optional
+`--telescope <name>` parameter; when omitted, the bot resolves the
+telescope from the channel the command was invoked in.
+
+| Command | NINA endpoint(s) | Description |
+|---------|------------------|-------------|
+| `/status` | mount/info + sequence/json + event-history + filterwheel/info | one-page summary embed |
+| `/sequence` | `/sequence/json` | containers, current target, meridian flip |
+| `/target` | `/sequence/json` + latest `TS-TARGETSTART` | name, coords, rotation, time remaining |
+| `/mount` | `/equipment/mount/info` | RA/Dec, Alt/Az, pier side, tracking, flip ETA |
+| `/filter` | `/equipment/filterwheel/info` | current + available filters |
+| `/focus` | `/equipment/focuser/last-af` | last AF: HFR, R², position, temperature |
+| `/guider` | `/equipment/guider/info` | RMS, pixel scale, state |
+| `/events [count]` | `/event-history` | last N events |
+| `/last-image` | `/image/{idx}` + `/image/thumbnail/{idx}` | embed + thumbnail attachment |
+
+Outbound message routing (event/image notifications) flows through the new
+bot service for any telescope with `discord_channel_id` set. No visible
+change for existing webhook-only telescopes.
+
+### Phase 2 — live status message
+
+Each bot-routed telescope gets a pinned embed in its channel, edited in
+place on every poll cycle. Posted on first run; the message ID is
+persisted to `./spacecat-state.json` (CWD by default; configurable via
+`chat.discord_bot.state_file`).
+
+State file schema:
+
+```json
+{
+  "status_messages": {
+    "c925":     { "channel_id": "111", "message_id": "999" },
+    "askar107": { "channel_id": "222", "message_id": "888" }
+  }
+}
+```
+
+Operational flow per poll cycle:
+
+1. Poll sequence / events / images (unchanged).
+2. Post new event messages and new image messages (unchanged — the status
+   message **supplements**, it does not replace, the event stream).
+3. Rebuild the status embed and `edit_message(channel_id, message_id, embed)`.
+4. If the edit returns 404 (message deleted), post a fresh status message
+   and update the state file entry.
+
+Atomic file writes via tempfile + rename. Reads on startup.
+
+Live status embed fields:
+
+- Current target (name, project, coords)
+- Sequence progress (running / paused / finished, container count)
+- Mount state (parked / tracking / slewing, RA/Dec, pier side)
+- Last filter (name + ID)
+- Guider RMS (total arcsec)
+- Last image HFR + stars
+- Meridian flip ETA
+- Last autofocus R² + position change
+
+### Phase 3 — write commands (ACL-gated)
+
+Every write command:
+
+1. Checks invoker's Discord user ID against `chat.discord_bot.write_acl`.
+   Reject with an ephemeral error if not authorized.
+2. For destructive actions (park, abort, stop-sequence), requires a button
+   confirmation via `poise::CreateReply::components` before issuing the
+   API call.
+
+| Command | NINA endpoint | Destructive |
+|---------|---------------|-------------|
+| `/park` | `POST /equipment/mount/park` | ✓ (confirm) |
+| `/unpark` | `POST /equipment/mount/unpark` | |
+| `/home` | `POST /equipment/mount/home` | |
+| `/change-filter <name>` | `POST /equipment/filterwheel/change-filter/{id}` | |
+| `/move-focuser <pos>` | `POST /equipment/focuser/move-by-position/{n}` | |
+| `/rotate <angle>` | `POST /equipment/rotator/move-mechanical/{n}` | |
+| `/dither` | `POST /equipment/guider/dither` | |
+| `/abort-capture` | `POST /equipment/camera/abort` | ✓ |
+| `/pause-sequence` | `POST /sequence/pause` | |
+| `/resume-sequence` | `POST /sequence/resume` | |
+| `/start-sequence` | `POST /sequence/start` | ✓ (confirm) |
+| `/stop-sequence` | `POST /sequence/stop` | ✓ (confirm) |
+| `/cool <temp>` | `POST /equipment/camera/cool/{temp}` | |
+
+The exact NINA POST endpoints must be verified against the ninaAPI source
+before implementation — the earlier survey focused on events, not write
+endpoints.
+
+### Phase 4 — bot identity polish
+
+- Set bot presence: `Watching 4 telescopes`.
+- Optional rotation through per-telescope status messages
+  (`Watching c925 — guiding NGC 7000`).
+- Avatar / display name configurable.
+
+Pure cosmetics; no functional change.
+
+## Slash command channel-default resolution
+
+```rust
+async fn resolve_telescope<'a>(
+    ctx: Context<'a>,
+    override_name: Option<String>,
+) -> Result<&'a SpaceCatApiClient, Error> {
+    let data = ctx.data();
+    if let Some(name) = override_name {
+        return data
+            .api_clients
+            .get(&name)
+            .ok_or_else(|| format!("Unknown telescope '{name}'. Known: {:?}", data.known_names()).into());
+    }
+    if let Some(name) = data.channel_to_telescope.get(&ctx.channel_id()) {
+        return Ok(data.api_clients.get(name).expect("channel map invariant"));
+    }
+    Err(format!(
+        "No telescope mapped to this channel. Pass --telescope <name>. Known: {:?}",
+        data.known_names()
+    )
+    .into())
+}
+```
+
+This lets a single ops/admin channel drive every rig by explicit name,
+while per-telescope channels Just Work without specifying which one.
+
+## Routing decisions recap
+
+- **Bot scope:** single shared bot, one token, all telescopes.
+- **Precedence when both webhook + channel configured:** bot wins; webhook
+  ignored for that telescope.
+- **ACL granularity (Phase 3):** Discord user IDs to start. Role-based
+  ACLs can be added later if needed.
+- **State file path:** CWD, default `./spacecat-state.json`.
+- **Live status:** Phase 2 (supplements the event stream, doesn't replace it).
+
+## Open implementation questions (to resolve when coding starts)
+
+- Do slash commands need to be registered globally (slow, but works in
+  every guild) or per-guild (fast, requires knowing the guild ID)?
+  Per-guild is faster to iterate on during development; we can flip to
+  global before release.
+- Should the bot validate that every `discord_channel_id` is a channel it
+  can see at startup? Probably yes, with a warning per missing channel.
+- Thumbnail caching for `/last-image` — not required for correctness, but
+  avoids re-fetching the same thumbnail if the command is run repeatedly.

--- a/src/api.rs
+++ b/src/api.rs
@@ -366,4 +366,68 @@ impl SpaceCatApiClient {
         self.generic_request_with_retry("/equipment/guider/info", &[])
             .await
     }
+
+    /// Issue a NINA "command" endpoint (mount park, filter change, etc.).
+    ///
+    /// NINA exposes its write surface as plain GET requests with query
+    /// parameters under `/v2/api/...`. Unlike `generic_request_with_retry`,
+    /// this method does *not* retry on transient failures — most write
+    /// operations aren't safely idempotent (e.g. capture, slew). Returns
+    /// the parsed wrapper with `Success`/`Error`/`Response` fields.
+    pub async fn execute_command(
+        &self,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> Result<CommandResponse, ApiError> {
+        let url = format!("{}/v2/api{}", self.base_url, endpoint);
+        let mut request = self.client.get(&url);
+        if !params.is_empty() {
+            request = request.query(params);
+        }
+        let response = request.send().await?;
+        if response.status().is_success() {
+            let parsed: CommandResponse = response.json().await?;
+            Ok(parsed)
+        } else {
+            let status = response.status().as_u16();
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            Err(ApiError::Http { status, message })
+        }
+    }
+}
+
+/// Response shape from NINA's command endpoints. `response` is whatever the
+/// endpoint chose to return — usually a short status string — and is
+/// surfaced verbatim to chat replies.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CommandResponse {
+    pub response: serde_json::Value,
+    pub error: String,
+    pub status_code: i32,
+    pub success: bool,
+    #[serde(rename = "Type")]
+    pub response_type: String,
+}
+
+impl CommandResponse {
+    /// Best-effort human-readable summary of the response body.
+    pub fn summary(&self) -> String {
+        if !self.success {
+            return if self.error.is_empty() {
+                "failed".to_string()
+            } else {
+                format!("failed: {}", self.error)
+            };
+        }
+        match &self.response {
+            serde_json::Value::String(s) if !s.is_empty() => s.clone(),
+            serde_json::Value::Bool(b) => b.to_string(),
+            serde_json::Value::Null => "ok".to_string(),
+            other => other.to_string(),
+        }
+    }
 }

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -547,12 +547,10 @@ async fn target(
         embed = embed
             .field("Name", tname, true)
             .field("Project", project, true)
-            .field("Rotation", format!("{rot}°"), true)
-            .field(
-                "Coordinates",
-                format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                false,
-            );
+            .field("Rotation", format!("{rot}°"), true);
+        if let Some(s) = coords.display() {
+            embed = embed.field("Coordinates", s, false);
+        }
     } else {
         embed = embed.field("Sequence target", active_target, false);
     }

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -11,13 +11,16 @@
 //!   /status, /sequence, /target, /mount, /filter, /focus, /guider,
 //!   /events, /last-image.
 
+use super::status_state::{StatusMessage, StatusState};
 use super::{ChatMessage, ChatService, ChatTarget, DiscordBotConfig};
 use crate::api::SpaceCatApiClient;
 use crate::error::ChatError;
 use async_trait::async_trait;
 use poise::serenity_prelude::{self as serenity, CreateAttachment, CreateMessage};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 /// Per-bot state carried by the Poise framework. Each slash command has
 /// `ctx.data()` access to this.
@@ -81,17 +84,30 @@ pub type Context<'a> = poise::Context<'a, BotData, BotError>;
 // ---------- Outbound posting (ChatService impl) ----------
 
 /// Chat service that posts via the Discord bot. Holds the bot's `Arc<Http>`
-/// after the gateway task is spawned, plus an optional default channel.
+/// after the gateway task is spawned, plus an optional default channel and
+/// the persistent live-status state.
 pub struct DiscordBotService {
     http: Arc<serenity::Http>,
     default_channel_id: Option<u64>,
+    /// Per-telescope (channel_id, message_id) for the pinned live-status
+    /// message. Shared across telescope tasks via Mutex; reads are cheap,
+    /// writes happen once per poll cycle per telescope.
+    status_state: Arc<Mutex<StatusState>>,
+    state_file: PathBuf,
 }
 
 impl DiscordBotService {
-    pub fn new(http: Arc<serenity::Http>, default_channel_id: Option<u64>) -> Self {
+    pub fn new(
+        http: Arc<serenity::Http>,
+        default_channel_id: Option<u64>,
+        status_state: Arc<Mutex<StatusState>>,
+        state_file: PathBuf,
+    ) -> Self {
         Self {
             http,
             default_channel_id,
+            status_state,
+            state_file,
         }
     }
 
@@ -178,6 +194,89 @@ impl ChatService for DiscordBotService {
     fn can_route(&self, target: &ChatTarget) -> bool {
         target.discord_channel_id.is_some() || self.default_channel_id.is_some()
     }
+
+    fn supports_status_upsert(&self) -> bool {
+        true
+    }
+
+    /// Edit-or-post the live status message for this telescope.
+    ///
+    /// On first call (or when state has no record), posts a fresh message
+    /// and remembers `(channel_id, message_id)`. On subsequent calls, edits
+    /// the existing message in place. If the previous message was deleted
+    /// (404 from Discord), reposts and updates state.
+    async fn upsert_status(
+        &self,
+        telescope: &str,
+        target: &ChatTarget,
+        message: &ChatMessage,
+    ) -> Result<(), ChatError> {
+        let channel = self
+            .resolve_channel(target)
+            .ok_or_else(|| ChatError::Discord {
+                message: "No Discord channel available for status upsert".to_string(),
+            })?;
+        let embed = Self::build_embed(message);
+
+        let existing = {
+            let state = self.status_state.lock().await;
+            state.get(telescope)
+        };
+
+        // Try to edit if we have a known message in the same channel.
+        if let Some(known) = existing
+            && known.channel_id == channel.get()
+        {
+            let edit = serenity::EditMessage::new()
+                .content("")
+                .embed(embed.clone());
+            match channel
+                .edit_message(&self.http, serenity::MessageId::new(known.message_id), edit)
+                .await
+            {
+                Ok(_) => return Ok(()),
+                Err(serenity::Error::Http(serenity::HttpError::UnsuccessfulRequest(err)))
+                    if err.status_code == reqwest::StatusCode::NOT_FOUND =>
+                {
+                    // Message was deleted; fall through and repost.
+                    eprintln!(
+                        "[{telescope}] status message {} not found — reposting",
+                        known.message_id
+                    );
+                }
+                Err(e) => {
+                    return Err(ChatError::Discord {
+                        message: format!("edit_message failed: {e}"),
+                    });
+                }
+            }
+        }
+
+        // Post new message and record its ID.
+        let payload = CreateMessage::new().embed(embed);
+        let posted = channel
+            .send_message(&self.http, payload)
+            .await
+            .map_err(|e| ChatError::Discord {
+                message: format!("status post failed: {e}"),
+            })?;
+
+        let mut state = self.status_state.lock().await;
+        state.set(
+            telescope,
+            StatusMessage {
+                channel_id: channel.get(),
+                message_id: posted.id.get(),
+            },
+        );
+        if let Err(e) = state.save(&self.state_file) {
+            eprintln!(
+                "Warning: failed to persist status state to {}: {e}",
+                self.state_file.display()
+            );
+        }
+        Ok(())
+    }
 }
 
 // ---------- Bot startup ----------
@@ -195,6 +294,15 @@ pub async fn run_bot(
     let write_acl: std::collections::HashSet<u64> = bot_config.write_acl.iter().copied().collect();
     let token = bot_config.token.clone();
     let default_channel_id = bot_config.default_channel_id;
+    let state_file = PathBuf::from(&bot_config.state_file);
+    let status_state = StatusState::load(&state_file).unwrap_or_else(|e| {
+        eprintln!(
+            "Warning: could not load status state from {}: {e} — starting fresh",
+            state_file.display()
+        );
+        StatusState::default()
+    });
+    let status_state = Arc::new(Mutex::new(status_state));
 
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
@@ -238,23 +346,36 @@ pub async fn run_bot(
         }
     });
 
-    Ok((DiscordBotService::new(http, default_channel_id), join))
+    Ok((
+        DiscordBotService::new(http, default_channel_id, status_state, state_file),
+        join,
+    ))
 }
 
 // ---------- Slash commands (Phase 1, read-only) ----------
 
+/// SpaceCat telescope monitoring commands.
+#[poise::command(
+    slash_command,
+    subcommands(
+        "status",
+        "sequence",
+        "target",
+        "mount",
+        "filter",
+        "focus",
+        "guider",
+        "events",
+        "last_image"
+    )
+)]
+async fn spacecat(_ctx: Context<'_>) -> Result<(), BotError> {
+    // Parent never runs directly when subcommands are defined.
+    Ok(())
+}
+
 fn phase1_commands() -> Vec<poise::Command<BotData, BotError>> {
-    vec![
-        status(),
-        sequence(),
-        target(),
-        mount(),
-        filter(),
-        focus(),
-        guider(),
-        events(),
-        last_image(),
-    ]
+    vec![spacecat()]
 }
 
 /// Shorthand for "resolve telescope, send an ephemeral error to the user if

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -387,6 +387,7 @@ pub async fn run_bot(
         "guider_stop",
         "cool",
         "warm",
+        "autofocus",
         "abort_capture",
         "stop_sequence",
         "start_sequence",
@@ -1127,6 +1128,41 @@ async fn warm(
 }
 
 // --- Destructive (ACL + button confirm) ---
+
+/// Trigger a NINA autofocus run, or cancel one with `cancel:true`.
+#[poise::command(slash_command)]
+async fn autofocus(
+    ctx: Context<'_>,
+    #[description = "Cancel a running API-triggered autofocus"] cancel: Option<bool>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let cancel = cancel.unwrap_or(false);
+    if !cancel && !confirm_destructive(ctx, &format!("autofocus run on {name}")).await? {
+        return Ok(());
+    }
+    let label = if cancel {
+        "Cancel autofocus"
+    } else {
+        "Start autofocus"
+    };
+    let cancel_str = if cancel { "true" } else { "false" };
+    run_command(
+        ctx,
+        &name,
+        &client,
+        label,
+        "/equipment/focuser/auto-focus",
+        &[("cancel", cancel_str)],
+    )
+    .await
+}
 
 /// Park the mount (requires confirmation).
 #[poise::command(slash_command)]

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -1,0 +1,646 @@
+//! Process-wide Discord bot using Serenity + Poise.
+//!
+//! One bot identity (one token) serves every telescope. Each telescope can
+//! map to a Discord channel via `TelescopeChatOverrides::discord_channel_id`;
+//! slash commands invoked in that channel default to that telescope. Outbound
+//! posts (events, image notifications, etc.) flow through this service via
+//! `ChatService::send_message` and use the bot's `Arc<Http>` to deliver
+//! directly without going through the gateway loop.
+//!
+//! Read-only slash commands (Phase 1):
+//!   /status, /sequence, /target, /mount, /filter, /focus, /guider,
+//!   /events, /last-image.
+
+use super::{ChatMessage, ChatService, ChatTarget, DiscordBotConfig};
+use crate::api::SpaceCatApiClient;
+use crate::error::ChatError;
+use async_trait::async_trait;
+use poise::serenity_prelude::{self as serenity, CreateAttachment, CreateMessage};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Per-bot state carried by the Poise framework. Each slash command has
+/// `ctx.data()` access to this.
+pub struct BotData {
+    /// One API client per telescope, keyed by telescope name.
+    pub api_clients: HashMap<String, SpaceCatApiClient>,
+    /// Discord channel ID -> telescope name. Slash commands invoked in a
+    /// mapped channel default to that telescope.
+    pub channel_to_telescope: HashMap<u64, String>,
+    /// Discord user IDs allowed to invoke write commands (Phase 3).
+    #[allow(dead_code)]
+    pub write_acl: std::collections::HashSet<u64>,
+}
+
+impl BotData {
+    fn known_names(&self) -> Vec<&str> {
+        let mut v: Vec<&str> = self.api_clients.keys().map(|s| s.as_str()).collect();
+        v.sort();
+        v
+    }
+
+    /// Resolve a telescope from an explicit override or the channel a
+    /// command was invoked in. Returns a user-facing error string if the
+    /// channel isn't mapped and no override was provided.
+    fn resolve_client(
+        &self,
+        override_name: Option<&str>,
+        channel_id: u64,
+    ) -> Result<(String, SpaceCatApiClient), String> {
+        if let Some(name) = override_name {
+            return self
+                .api_clients
+                .get(name)
+                .cloned()
+                .map(|c| (name.to_string(), c))
+                .ok_or_else(|| {
+                    format!(
+                        "Unknown telescope '{name}'. Known: {:?}",
+                        self.known_names()
+                    )
+                });
+        }
+        if let Some(name) = self.channel_to_telescope.get(&channel_id) {
+            let client = self
+                .api_clients
+                .get(name)
+                .cloned()
+                .expect("channel_to_telescope -> api_clients invariant");
+            return Ok((name.clone(), client));
+        }
+        Err(format!(
+            "No telescope mapped to this channel. Pass `telescope:<name>`. Known: {:?}",
+            self.known_names()
+        ))
+    }
+}
+
+pub type BotError = Box<dyn std::error::Error + Send + Sync>;
+pub type Context<'a> = poise::Context<'a, BotData, BotError>;
+
+// ---------- Outbound posting (ChatService impl) ----------
+
+/// Chat service that posts via the Discord bot. Holds the bot's `Arc<Http>`
+/// after the gateway task is spawned, plus an optional default channel.
+pub struct DiscordBotService {
+    http: Arc<serenity::Http>,
+    default_channel_id: Option<u64>,
+}
+
+impl DiscordBotService {
+    pub fn new(http: Arc<serenity::Http>, default_channel_id: Option<u64>) -> Self {
+        Self {
+            http,
+            default_channel_id,
+        }
+    }
+
+    fn resolve_channel(&self, target: &ChatTarget) -> Option<serenity::ChannelId> {
+        target
+            .discord_channel_id
+            .or(self.default_channel_id)
+            .map(serenity::ChannelId::new)
+    }
+
+    fn build_embed(message: &ChatMessage) -> serenity::CreateEmbed {
+        let mut embed = serenity::CreateEmbed::new().title(&message.title);
+        if let Some(color) = message.color {
+            embed = embed.color(color);
+        }
+        for field in &message.fields {
+            embed = embed.field(&field.name, &field.value, field.inline);
+        }
+        if let Some(footer) = &message.footer {
+            embed = embed.footer(serenity::CreateEmbedFooter::new(footer));
+        }
+        if let Some(ts) = &message.timestamp
+            && let Ok(parsed) = serenity::Timestamp::parse(ts)
+        {
+            embed = embed.timestamp(parsed);
+        }
+        embed
+    }
+}
+
+#[async_trait]
+impl ChatService for DiscordBotService {
+    async fn send_message(
+        &self,
+        message: &ChatMessage,
+        target: &ChatTarget,
+    ) -> Result<(), ChatError> {
+        let channel = self
+            .resolve_channel(target)
+            .ok_or_else(|| ChatError::Discord {
+                message: "No Discord channel available (no default and no telescope override)"
+                    .to_string(),
+            })?;
+        let payload = CreateMessage::new().embed(Self::build_embed(message));
+        channel
+            .send_message(&self.http, payload)
+            .await
+            .map_err(|e| ChatError::Discord {
+                message: e.to_string(),
+            })?;
+        Ok(())
+    }
+
+    async fn send_message_with_image(
+        &self,
+        message: &ChatMessage,
+        target: &ChatTarget,
+        image_data: &[u8],
+        filename: &str,
+    ) -> Result<(), ChatError> {
+        let channel = self
+            .resolve_channel(target)
+            .ok_or_else(|| ChatError::Discord {
+                message: "No Discord channel available (no default and no telescope override)"
+                    .to_string(),
+            })?;
+        let attachment = CreateAttachment::bytes(image_data.to_vec(), filename);
+        let payload = CreateMessage::new()
+            .embed(Self::build_embed(message))
+            .add_file(attachment);
+        channel
+            .send_message(&self.http, payload)
+            .await
+            .map_err(|e| ChatError::Discord {
+                message: e.to_string(),
+            })?;
+        Ok(())
+    }
+
+    fn service_name(&self) -> &'static str {
+        "Discord (bot)"
+    }
+
+    fn can_route(&self, target: &ChatTarget) -> bool {
+        target.discord_channel_id.is_some() || self.default_channel_id.is_some()
+    }
+}
+
+// ---------- Bot startup ----------
+
+/// Start the Discord bot. Builds a Serenity client wired with the Poise
+/// framework + Phase 1 commands, spawns the gateway loop, and returns the
+/// service handle (which holds `Arc<Http>`) plus the join handle for the
+/// gateway task. The join handle is kept by the caller so the service stays
+/// alive for the life of the process.
+pub async fn run_bot(
+    bot_config: &DiscordBotConfig,
+    api_clients: HashMap<String, SpaceCatApiClient>,
+    channel_to_telescope: HashMap<u64, String>,
+) -> Result<(DiscordBotService, tokio::task::JoinHandle<()>), ChatError> {
+    let write_acl: std::collections::HashSet<u64> = bot_config.write_acl.iter().copied().collect();
+    let token = bot_config.token.clone();
+    let default_channel_id = bot_config.default_channel_id;
+
+    let framework = poise::Framework::builder()
+        .options(poise::FrameworkOptions {
+            commands: phase1_commands(),
+            ..Default::default()
+        })
+        .setup(move |ctx, ready, framework| {
+            Box::pin(async move {
+                println!(
+                    "Discord bot connected as {} (id {}), guilds: {}",
+                    ready.user.name,
+                    ready.user.id,
+                    ready.guilds.len()
+                );
+                poise::builtins::register_globally(ctx, &framework.options().commands)
+                    .await
+                    .map_err(|e| -> BotError { Box::new(e) })?;
+                Ok(BotData {
+                    api_clients,
+                    channel_to_telescope,
+                    write_acl,
+                })
+            })
+        })
+        .build();
+
+    let intents = serenity::GatewayIntents::GUILDS;
+    let mut client = serenity::ClientBuilder::new(&token, intents)
+        .framework(framework)
+        .await
+        .map_err(|e| ChatError::Initialization {
+            service_name: "Discord bot".to_string(),
+            reason: e.to_string(),
+        })?;
+
+    let http = client.http.clone();
+
+    let join = tokio::spawn(async move {
+        if let Err(e) = client.start().await {
+            eprintln!("Discord bot gateway error: {e}");
+        }
+    });
+
+    Ok((DiscordBotService::new(http, default_channel_id), join))
+}
+
+// ---------- Slash commands (Phase 1, read-only) ----------
+
+fn phase1_commands() -> Vec<poise::Command<BotData, BotError>> {
+    vec![
+        status(),
+        sequence(),
+        target(),
+        mount(),
+        filter(),
+        focus(),
+        guider(),
+        events(),
+        last_image(),
+    ]
+}
+
+/// Shorthand for "resolve telescope, send an ephemeral error to the user if
+/// it fails."
+async fn resolve_or_reply<'a>(
+    ctx: Context<'a>,
+    telescope: Option<String>,
+) -> Result<(String, SpaceCatApiClient), BotError> {
+    match ctx
+        .data()
+        .resolve_client(telescope.as_deref(), ctx.channel_id().get())
+    {
+        Ok(v) => Ok(v),
+        Err(msg) => {
+            ctx.send(poise::CreateReply::default().content(msg).ephemeral(true))
+                .await?;
+            Err("telescope resolution failed".into())
+        }
+    }
+}
+
+/// One-page summary embed: target + mount + sequence + filter.
+#[poise::command(slash_command)]
+async fn status(
+    ctx: Context<'_>,
+    #[description = "Telescope name (defaults to this channel's telescope)"] telescope: Option<
+        String,
+    >,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+
+    let mut embed = serenity::CreateEmbed::new().title(format!("[{name}] Status"));
+
+    if let Ok(mount) = client.get_mount_info().await {
+        let (ra, dec) = mount.get_coordinates();
+        let (alt, az) = mount.get_alt_az();
+        embed = embed.field(
+            "Mount",
+            format!(
+                "Connected: {}\nTracking: {}\nParked: {}\nRA: {} Dec: {}\nAlt: {} Az: {}",
+                mount.is_connected(),
+                mount.response.tracking_enabled,
+                mount.response.at_park,
+                ra,
+                dec,
+                alt,
+                az
+            ),
+            false,
+        );
+    }
+
+    if let Ok(seq) = client.get_sequence().await {
+        let containers = seq.get_containers();
+        let running = containers
+            .iter()
+            .filter(|c| c.status.eq_ignore_ascii_case("RUNNING"))
+            .count();
+        let active_target =
+            crate::sequence::extract_current_target(&seq).unwrap_or_else(|| "(none)".to_string());
+        embed = embed.field(
+            "Sequence",
+            format!(
+                "Target: {active_target}\nContainers: {} total, {running} running",
+                containers.len()
+            ),
+            false,
+        );
+    }
+
+    if let Ok(fw) = client.get_filterwheel_info().await
+        && fw.response.connected
+        && let Some(sel) = &fw.response.selected_filter
+    {
+        embed = embed.field("Filter", format!("{} (ID: {})", sel.name, sel.id), true);
+    }
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn sequence(
+    ctx: Context<'_>,
+    #[description = "Telescope name (defaults to this channel's telescope)"] telescope: Option<
+        String,
+    >,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let seq = client.get_sequence().await?;
+    let containers = seq.get_containers();
+    let lines: Vec<String> = containers
+        .iter()
+        .map(|c| format!("• {} — {} ({} items)", c.name, c.status, c.items.len()))
+        .collect();
+    let active_target =
+        crate::sequence::extract_current_target(&seq).unwrap_or_else(|| "(none)".to_string());
+    let flip = crate::sequence::extract_meridian_flip_time(&seq)
+        .map(crate::sequence::meridian_flip_time_formatted_with_clock)
+        .unwrap_or_else(|| "(n/a)".to_string());
+
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Sequence"))
+        .field("Active target", active_target, true)
+        .field("Meridian flip in", flip, true)
+        .field("Containers", lines.join("\n"), false);
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn target(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let seq = client.get_sequence().await?;
+    let active_target =
+        crate::sequence::extract_current_target(&seq).unwrap_or_else(|| "(none)".to_string());
+
+    // Look for the latest TS-TARGETSTART event for richer coords.
+    let events = client.get_event_history().await.ok();
+    let ts_target = events.as_ref().and_then(|e| {
+        e.response.iter().rev().find_map(|ev| {
+            if let Some(crate::events::EventDetails::TargetStart {
+                target_name,
+                coordinates,
+                project_name,
+                rotation,
+                ..
+            }) = &ev.details
+            {
+                Some((
+                    target_name.clone(),
+                    coordinates.clone(),
+                    project_name.clone(),
+                    *rotation,
+                ))
+            } else {
+                None
+            }
+        })
+    });
+
+    let mut embed = serenity::CreateEmbed::new().title(format!("[{name}] Target"));
+    if let Some((tname, coords, project, rot)) = ts_target {
+        embed = embed
+            .field("Name", tname, true)
+            .field("Project", project, true)
+            .field("Rotation", format!("{rot}°"), true)
+            .field(
+                "Coordinates",
+                format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
+                false,
+            );
+    } else {
+        embed = embed.field("Sequence target", active_target, false);
+    }
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn mount(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let mount = client.get_mount_info().await?;
+    let m = &mount.response;
+    let (ra, dec) = mount.get_coordinates();
+    let (alt, az) = mount.get_alt_az();
+    let flip = mount.get_time_to_meridian_flip_string();
+
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Mount"))
+        .field(
+            "Status",
+            format!(
+                "Connected: {}\nTracking: {}\nParked: {}\nSlewing: {}\nAt home: {}",
+                m.connected, m.tracking_enabled, m.at_park, m.slewing, m.at_home
+            ),
+            false,
+        )
+        .field("RA / Dec", format!("RA: {ra}\nDec: {dec}"), true)
+        .field("Alt / Az", format!("Alt: {alt}\nAz: {az}"), true)
+        .field("Pier side", mount.get_side_of_pier().to_string(), true)
+        .field("Sidereal time", &m.sidereal_time_string, true)
+        .field("Time to flip", flip, true);
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn filter(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let fw = client.get_filterwheel_info().await?;
+    let mut embed = serenity::CreateEmbed::new().title(format!("[{name}] Filter wheel"));
+    if let Some(sel) = &fw.response.selected_filter {
+        embed = embed.field("Selected", format!("{} (ID: {})", sel.name, sel.id), false);
+    } else {
+        embed = embed.field("Selected", "(none)", false);
+    }
+    if !fw.response.available_filters.is_empty() {
+        let avail = fw
+            .response
+            .available_filters
+            .iter()
+            .map(|f| format!("{} ({})", f.name, f.id))
+            .collect::<Vec<_>>()
+            .join(", ");
+        embed = embed.field("Available", avail, false);
+    }
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn focus(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let af = client.get_last_autofocus().await?;
+    let d = &af.response;
+    let position_change = d.calculated_focus_point.position - d.previous_focus_point.position;
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Last autofocus"))
+        .field("Filter", &d.filter, true)
+        .field("Method", &d.method, true)
+        .field("Duration", &d.duration, true)
+        .field("Temperature", format!("{:.1}°C", d.temperature), true)
+        .field(
+            "Position",
+            format!(
+                "{} (Δ {:+})",
+                d.calculated_focus_point.position, position_change
+            ),
+            true,
+        )
+        .field(
+            "HFR",
+            format!("{:.3}", d.calculated_focus_point.value),
+            true,
+        )
+        .field("Best R²", format!("{:.4}", af.get_best_r_squared()), true)
+        .field("Timestamp", &d.timestamp, true);
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn guider(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let info = client.get_guider_info().await?;
+    let g = &info.response;
+    let mut embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Guider"))
+        .field("Connected", g.connected.to_string(), true)
+        .field("State", &g.state, true);
+    if g.pixel_scale > 0.0 {
+        embed = embed.field(
+            "Pixel scale",
+            format!("{:.3} arcsec/px", g.pixel_scale),
+            true,
+        );
+    }
+    if let Some(rms) = &g.rms_error {
+        embed = embed.field(
+            "RMS error",
+            format!(
+                "Total: {:.2}\"\nRA: {:.2}\"  Dec: {:.2}\"",
+                rms.total.arcseconds, rms.ra.arcseconds, rms.dec.arcseconds
+            ),
+            false,
+        );
+    }
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn events(
+    ctx: Context<'_>,
+    #[description = "Number of events to show (default 10)"] count: Option<u32>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let history = client.get_event_history().await?;
+    let count = count.unwrap_or(10).min(25) as usize;
+    let events: Vec<&crate::events::Event> = history.response.iter().rev().take(count).collect();
+    let lines: Vec<String> = events
+        .iter()
+        .rev()
+        .map(|e| format!("`{}` {}", e.time, e.event))
+        .collect();
+    let embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Last {count} events"))
+        .description(if lines.is_empty() {
+            "(no events)".to_string()
+        } else {
+            lines.join("\n")
+        });
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
+    Ok(())
+}
+
+#[poise::command(slash_command, rename = "last-image")]
+async fn last_image(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let images = client.get_all_image_history().await?;
+    let Some((idx, img)) = images.response.iter().enumerate().next_back() else {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("No images in history.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    };
+
+    let thumb_bytes = client.get_thumbnail(idx as u32).await.ok().map(|t| t.data);
+
+    let mut embed = serenity::CreateEmbed::new()
+        .title(format!("[{name}] Last image"))
+        .field("Date", &img.date, true)
+        .field("Type", &img.image_type, true)
+        .field("Filter", &img.filter, true)
+        .field("Exposure", format!("{:.1}s", img.exposure_time), true)
+        .field("Temperature", format!("{:.1}°C", img.temperature), true)
+        .field("Stars", img.stars.to_string(), true)
+        .field("HFR", format!("{:.2}", img.hfr), true)
+        .field("RMS", &img.rms_text, true);
+
+    let mut reply = poise::CreateReply::default();
+    if let Some(bytes) = thumb_bytes {
+        let filename = format!("thumbnail_{idx}.jpg");
+        embed = embed.image(format!("attachment://{filename}"));
+        reply = reply.attachment(CreateAttachment::bytes(bytes, filename));
+    }
+    reply = reply.embed(embed);
+    ctx.send(reply).await?;
+    Ok(())
+}

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -94,6 +94,8 @@ pub struct DiscordBotService {
     /// writes happen once per poll cycle per telescope.
     status_state: Arc<Mutex<StatusState>>,
     state_file: PathBuf,
+    /// Whether live-status upserts are enabled at all (config-driven).
+    live_status: bool,
 }
 
 impl DiscordBotService {
@@ -102,12 +104,14 @@ impl DiscordBotService {
         default_channel_id: Option<u64>,
         status_state: Arc<Mutex<StatusState>>,
         state_file: PathBuf,
+        live_status: bool,
     ) -> Self {
         Self {
             http,
             default_channel_id,
             status_state,
             state_file,
+            live_status,
         }
     }
 
@@ -196,7 +200,7 @@ impl ChatService for DiscordBotService {
     }
 
     fn supports_status_upsert(&self) -> bool {
-        true
+        self.live_status
     }
 
     /// Edit-or-post the live status message for this telescope.
@@ -347,7 +351,13 @@ pub async fn run_bot(
     });
 
     Ok((
-        DiscordBotService::new(http, default_channel_id, status_state, state_file),
+        DiscordBotService::new(
+            http,
+            default_channel_id,
+            status_state,
+            state_file,
+            bot_config.live_status,
+        ),
         join,
     ))
 }

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -368,6 +368,7 @@ pub async fn run_bot(
 #[poise::command(
     slash_command,
     subcommands(
+        // Read-only (anyone)
         "status",
         "sequence",
         "target",
@@ -376,7 +377,19 @@ pub async fn run_bot(
         "focus",
         "guider",
         "events",
-        "last_image"
+        "last_image",
+        // Write (ACL-gated; destructive ones require confirmation)
+        "park",
+        "unpark",
+        "home",
+        "change_filter",
+        "guider_start",
+        "guider_stop",
+        "cool",
+        "warm",
+        "abort_capture",
+        "stop_sequence",
+        "start_sequence",
     )
 )]
 async fn spacecat(_ctx: Context<'_>) -> Result<(), BotError> {
@@ -772,4 +785,451 @@ async fn last_image(
     reply = reply.embed(embed);
     ctx.send(reply).await?;
     Ok(())
+}
+
+// ---------- Phase 3: write commands (ACL-gated) ----------
+
+/// Reject the invocation with an ephemeral message if the invoking user is
+/// not in `chat.discord_bot.write_acl`. Returns `Ok(())` when authorized.
+async fn require_write_acl(ctx: Context<'_>) -> Result<(), BotError> {
+    let user_id = ctx.author().id.get();
+    if ctx.data().write_acl.contains(&user_id) {
+        return Ok(());
+    }
+    ctx.send(
+        poise::CreateReply::default()
+            .content(format!(
+                "🔒 You are not authorized to issue write commands. \
+                 Your user ID `{user_id}` is not in `chat.discord_bot.write_acl`."
+            ))
+            .ephemeral(true),
+    )
+    .await?;
+    Err("user not in write_acl".into())
+}
+
+/// Post a Confirm / Cancel button pair and wait for the invoker to click.
+/// Returns `Ok(true)` on Confirm, `Ok(false)` on Cancel or 30s timeout.
+async fn confirm_destructive(ctx: Context<'_>, action: &str) -> Result<bool, BotError> {
+    let prompt =
+        format!("⚠️ Confirm **{action}**?\nThis is a destructive operation — you have 30 seconds.");
+    let row = serenity::CreateActionRow::Buttons(vec![
+        serenity::CreateButton::new("spacecat-confirm")
+            .label("Confirm")
+            .style(serenity::ButtonStyle::Danger),
+        serenity::CreateButton::new("spacecat-cancel")
+            .label("Cancel")
+            .style(serenity::ButtonStyle::Secondary),
+    ]);
+    let handle = ctx
+        .send(
+            poise::CreateReply::default()
+                .content(prompt)
+                .components(vec![row])
+                .ephemeral(true),
+        )
+        .await?;
+    let message = handle.message().await?;
+
+    let interaction = message
+        .await_component_interaction(ctx.serenity_context().shard.clone())
+        .author_id(ctx.author().id)
+        .timeout(std::time::Duration::from_secs(30))
+        .await;
+
+    let (confirmed, response_text) = match interaction.as_ref().map(|i| i.data.custom_id.as_str()) {
+        Some("spacecat-confirm") => (true, "✅ Confirmed, running command…"),
+        Some("spacecat-cancel") => (false, "❎ Cancelled."),
+        _ => (false, "⏱️ Timed out — no action taken."),
+    };
+
+    // Acknowledge the interaction (or just edit the original message if
+    // the user didn't click anything).
+    if let Some(i) = interaction {
+        let _ = i
+            .create_response(
+                &ctx.serenity_context().http,
+                serenity::CreateInteractionResponse::UpdateMessage(
+                    serenity::CreateInteractionResponseMessage::new()
+                        .content(response_text)
+                        .components(vec![]),
+                ),
+            )
+            .await;
+    } else {
+        let _ = handle
+            .edit(
+                ctx,
+                poise::CreateReply::default()
+                    .content(response_text)
+                    .components(vec![]),
+            )
+            .await;
+    }
+    Ok(confirmed)
+}
+
+/// Issue a NINA command endpoint and reply with a status line. Used by all
+/// write commands once authorization (and any confirmation) has passed.
+async fn run_command(
+    ctx: Context<'_>,
+    telescope: &str,
+    client: &SpaceCatApiClient,
+    label: &str,
+    endpoint: &str,
+    params: &[(&str, &str)],
+) -> Result<(), BotError> {
+    let result = client.execute_command(endpoint, params).await;
+    let reply = match result {
+        Ok(resp) if resp.success => poise::CreateReply::default()
+            .content(format!("✅ [{telescope}] {label}: {}", resp.summary())),
+        Ok(resp) => poise::CreateReply::default()
+            .ephemeral(true)
+            .content(format!("❌ [{telescope}] {label}: {}", resp.summary())),
+        Err(e) => poise::CreateReply::default()
+            .ephemeral(true)
+            .content(format!("❌ [{telescope}] {label} failed: {e}")),
+    };
+    ctx.send(reply).await?;
+    Ok(())
+}
+
+// --- Non-destructive (ACL only) ---
+
+/// Unpark the mount.
+#[poise::command(slash_command)]
+async fn unpark(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Unpark mount",
+        "/equipment/mount/unpark",
+        &[],
+    )
+    .await
+}
+
+/// Send the mount to its home position.
+#[poise::command(slash_command)]
+async fn home(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Home mount",
+        "/equipment/mount/home",
+        &[],
+    )
+    .await
+}
+
+/// Change the filter wheel position by filter name (resolved to id via
+/// `/equipment/filterwheel/info`).
+#[poise::command(slash_command, rename = "change-filter")]
+async fn change_filter(
+    ctx: Context<'_>,
+    #[description = "Filter name (e.g. L, R, G, B, HA)"] filter: String,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+
+    let info = match client.get_filterwheel_info().await {
+        Ok(i) => i,
+        Err(e) => {
+            ctx.send(
+                poise::CreateReply::default()
+                    .ephemeral(true)
+                    .content(format!("❌ [{name}] couldn't fetch filterwheel info: {e}")),
+            )
+            .await?;
+            return Ok(());
+        }
+    };
+
+    let target = info
+        .response
+        .available_filters
+        .iter()
+        .find(|f| f.name.eq_ignore_ascii_case(&filter));
+    let Some(target) = target else {
+        let known: Vec<&str> = info
+            .response
+            .available_filters
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        ctx.send(
+            poise::CreateReply::default()
+                .ephemeral(true)
+                .content(format!(
+                    "❌ [{name}] no filter '{filter}'. Known: {known:?}"
+                )),
+        )
+        .await?;
+        return Ok(());
+    };
+
+    let id = target.id.to_string();
+    run_command(
+        ctx,
+        &name,
+        &client,
+        &format!("Change filter → {} (ID {})", target.name, target.id),
+        "/equipment/filterwheel/change-filter",
+        &[("filterId", id.as_str())],
+    )
+    .await
+}
+
+/// Start guiding (without calibration).
+#[poise::command(slash_command, rename = "guider-start")]
+async fn guider_start(
+    ctx: Context<'_>,
+    #[description = "Run calibration first"] calibrate: Option<bool>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let cal = if calibrate.unwrap_or(false) {
+        "true"
+    } else {
+        "false"
+    };
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Start guiding",
+        "/equipment/guider/start",
+        &[("calibrate", cal)],
+    )
+    .await
+}
+
+/// Stop guiding.
+#[poise::command(slash_command, rename = "guider-stop")]
+async fn guider_stop(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Stop guiding",
+        "/equipment/guider/stop",
+        &[],
+    )
+    .await
+}
+
+/// Cool the camera to a target temperature over `minutes` minutes.
+#[poise::command(slash_command)]
+async fn cool(
+    ctx: Context<'_>,
+    #[description = "Target temperature in °C"] temperature: f64,
+    #[description = "Minutes to ramp down (default 10)"] minutes: Option<f64>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let t = temperature.to_string();
+    let m = minutes.unwrap_or(10.0).to_string();
+    run_command(
+        ctx,
+        &name,
+        &client,
+        &format!(
+            "Cool to {temperature:.1}°C over {} min",
+            minutes.unwrap_or(10.0)
+        ),
+        "/equipment/camera/cool",
+        &[("temperature", t.as_str()), ("minutes", m.as_str())],
+    )
+    .await
+}
+
+/// Warm the camera over `minutes` minutes.
+#[poise::command(slash_command)]
+async fn warm(
+    ctx: Context<'_>,
+    #[description = "Minutes to warm (default 10)"] minutes: Option<f64>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    ctx.defer().await?;
+    let m = minutes.unwrap_or(10.0).to_string();
+    run_command(
+        ctx,
+        &name,
+        &client,
+        &format!("Warm camera over {} min", minutes.unwrap_or(10.0)),
+        "/equipment/camera/warm",
+        &[("minutes", m.as_str())],
+    )
+    .await
+}
+
+// --- Destructive (ACL + button confirm) ---
+
+/// Park the mount (requires confirmation).
+#[poise::command(slash_command)]
+async fn park(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    if !confirm_destructive(ctx, &format!("park {name}")).await? {
+        return Ok(());
+    }
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Park mount",
+        "/equipment/mount/park",
+        &[],
+    )
+    .await
+}
+
+/// Abort the current camera exposure (requires confirmation).
+#[poise::command(slash_command, rename = "abort-capture")]
+async fn abort_capture(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    if !confirm_destructive(ctx, &format!("abort capture on {name}")).await? {
+        return Ok(());
+    }
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Abort capture",
+        "/equipment/camera/abort-exposure",
+        &[],
+    )
+    .await
+}
+
+/// Stop the running sequence (requires confirmation).
+#[poise::command(slash_command, rename = "stop-sequence")]
+async fn stop_sequence(
+    ctx: Context<'_>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    if !confirm_destructive(ctx, &format!("stop sequence on {name}")).await? {
+        return Ok(());
+    }
+    run_command(ctx, &name, &client, "Stop sequence", "/sequence/stop", &[]).await
+}
+
+/// Start the loaded sequence (requires confirmation).
+#[poise::command(slash_command, rename = "start-sequence")]
+async fn start_sequence(
+    ctx: Context<'_>,
+    #[description = "Skip pre-run validation"] skip_validation: Option<bool>,
+    #[description = "Telescope name"] telescope: Option<String>,
+) -> Result<(), BotError> {
+    if require_write_acl(ctx).await.is_err() {
+        return Ok(());
+    }
+    let (name, client) = match resolve_or_reply(ctx, telescope).await {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    if !confirm_destructive(ctx, &format!("start sequence on {name}")).await? {
+        return Ok(());
+    }
+    let skip = if skip_validation.unwrap_or(false) {
+        "true"
+    } else {
+        "false"
+    };
+    run_command(
+        ctx,
+        &name,
+        &client,
+        "Start sequence",
+        "/sequence/start",
+        &[("skipValidation", skip)],
+    )
+    .await
 }

--- a/src/chat/discord_service.rs
+++ b/src/chat/discord_service.rs
@@ -91,6 +91,11 @@ impl ChatService for DiscordChatService {
     }
 
     fn can_route(&self, target: &ChatTarget) -> bool {
+        // Defer to the Discord bot when a channel ID is configured for this
+        // telescope — bot path takes precedence over the webhook.
+        if target.discord_channel_id.is_some() {
+            return false;
+        }
         self.resolve_url(target).is_some()
     }
 }

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -144,7 +144,14 @@ pub struct DiscordBotConfig {
     /// Optional fallback channel for telescopes that don't override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_channel_id: Option<u64>,
-    /// Where to persist the live-status message IDs (Phase 2).
+    /// Maintain a pinned live-status message per bot-routed telescope's
+    /// channel, edited in place when the telescope's state changes. Default
+    /// off — explicit opt-in so users who only want event notifications
+    /// don't get a second message stream by surprise.
+    #[serde(default)]
+    pub live_status: bool,
+    /// Where to persist the live-status message IDs (only used when
+    /// `live_status` is true).
     #[serde(default = "default_state_file")]
     pub state_file: String,
     /// Discord user IDs allowed to invoke write commands (Phase 3).

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -129,6 +129,16 @@ pub struct DiscordBotConfig {
     pub enabled: bool,
     /// Bot token from the Discord Developer Portal.
     pub token: String,
+    /// Discord application ID. Not required for gateway-based slash commands
+    /// (Serenity infers it from the token), but useful to keep alongside the
+    /// token for HTTP interaction endpoints and tooling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub application_id: Option<u64>,
+    /// Discord public key, used to verify interaction payloads when running
+    /// command handlers over HTTP webhooks. Unused in the gateway path
+    /// (Phase 1), reserved for future use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
     /// Optional fallback channel for telescopes that don't override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_channel_id: Option<u64>,

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1,10 +1,12 @@
 mod discord_bot;
 mod discord_service;
 mod matrix_service;
+mod status_state;
 
 pub use discord_bot::{DiscordBotService, run_bot};
 pub use discord_service::DiscordChatService;
 pub use matrix_service::MatrixChatService;
+pub use status_state::{StatusMessage, StatusState};
 
 use crate::api::SpaceCatApiClient;
 use crate::error::ChatError;
@@ -204,6 +206,25 @@ pub trait ChatService: Send + Sync {
     /// telescope without a webhook override on a Discord service with no
     /// default).
     fn can_route(&self, target: &ChatTarget) -> bool;
+
+    /// Upsert a "live status" message: edit the previously-posted message
+    /// for this telescope in place if one exists, otherwise post a new
+    /// one and remember its ID. Default implementation is a no-op for
+    /// services that don't support editing (webhooks, Matrix).
+    async fn upsert_status(
+        &self,
+        _telescope: &str,
+        _target: &ChatTarget,
+        _message: &ChatMessage,
+    ) -> Result<(), ChatError> {
+        Ok(())
+    }
+
+    /// True if this service knows how to edit a previously-posted status
+    /// message. Used to decide whether to bother building the embed.
+    fn supports_status_upsert(&self) -> bool {
+        false
+    }
 }
 
 /// Chat service manager. One instance is shared across all telescopes; the
@@ -221,6 +242,32 @@ impl ChatServiceManager {
 
     pub fn add_service(&mut self, service: Box<dyn ChatService>) {
         self.services.push(service);
+    }
+
+    /// Refresh the live status message for a telescope across every service
+    /// that supports editing. Currently only the Discord bot acts on this.
+    pub async fn upsert_status(&self, telescope: &str, target: &ChatTarget, message: &ChatMessage) {
+        for service in &self.services {
+            if !service.supports_status_upsert() || !service.can_route(target) {
+                continue;
+            }
+            if let Err(e) = service.upsert_status(telescope, target, message).await {
+                eprintln!(
+                    "Failed to upsert status on {} for {telescope}: {}",
+                    service.service_name(),
+                    e
+                );
+            }
+        }
+    }
+
+    /// True when at least one service in the manager can edit live status
+    /// messages for this target. Lets callers skip building the embed
+    /// entirely when nothing would consume it.
+    pub fn has_status_upsert(&self, target: &ChatTarget) -> bool {
+        self.services
+            .iter()
+            .any(|s| s.supports_status_upsert() && s.can_route(target))
     }
 
     pub async fn send_message(&self, message: &ChatMessage, target: &ChatTarget) {

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -1,6 +1,8 @@
+mod discord_bot;
 mod discord_service;
 mod matrix_service;
 
+pub use discord_bot::{DiscordBotService, run_bot};
 pub use discord_service::DiscordChatService;
 pub use matrix_service::MatrixChatService;
 
@@ -61,10 +63,15 @@ impl ChatMessage {
 /// Per-telescope routing overrides. Each field, when `Some`, redirects this
 /// telescope's posts away from the shared default destination configured on
 /// the corresponding `ChatService`.
+///
+/// When `discord_channel_id` is set, the Discord bot service takes precedence
+/// over webhook posting for this telescope — the webhook service defers via
+/// `can_route`, and the bot routes the message to the channel.
 #[derive(Debug, Clone, Default)]
 pub struct ChatTarget {
     pub discord_webhook_url: Option<String>,
     pub matrix_room_id: Option<String>,
+    pub discord_channel_id: Option<u64>,
 }
 
 /// Shared Discord configuration. The webhook here is the fallback destination
@@ -101,23 +108,56 @@ fn default_enabled() -> bool {
 }
 
 /// Shared chat configuration at the top of the config file. Persistent
-/// connections (Matrix login) live here and are reused across telescopes.
+/// connections (Matrix login, Discord bot gateway) live here and are reused
+/// across telescopes.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ChatConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discord: Option<SharedDiscordConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matrix: Option<SharedMatrixConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discord_bot: Option<DiscordBotConfig>,
+}
+
+/// Shared Discord bot configuration. One bot identity / token serves every
+/// telescope; each telescope can map to a different channel via
+/// `TelescopeChatOverrides::discord_channel_id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscordBotConfig {
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Bot token from the Discord Developer Portal.
+    pub token: String,
+    /// Optional fallback channel for telescopes that don't override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_channel_id: Option<u64>,
+    /// Where to persist the live-status message IDs (Phase 2).
+    #[serde(default = "default_state_file")]
+    pub state_file: String,
+    /// Discord user IDs allowed to invoke write commands (Phase 3).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub write_acl: Vec<u64>,
+}
+
+fn default_state_file() -> String {
+    "./spacecat-state.json".to_string()
 }
 
 /// Per-telescope chat routing overrides. Either field, when present, replaces
-/// the shared default for that service for this telescope only.
+/// the shared default for that service for this telescope only. Setting
+/// `discord_channel_id` switches that telescope's Discord posts from the
+/// webhook path to the bot path.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TelescopeChatOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discord_webhook_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub matrix_room_id: Option<String>,
+    /// When set, this telescope's Discord posts go through the bot to this
+    /// channel; the webhook path is ignored for it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discord_channel_id: Option<u64>,
 }
 
 impl TelescopeChatOverrides {
@@ -125,6 +165,7 @@ impl TelescopeChatOverrides {
         ChatTarget {
             discord_webhook_url: self.discord_webhook_url.clone(),
             matrix_room_id: self.matrix_room_id.clone(),
+            discord_channel_id: self.discord_channel_id,
         }
     }
 }

--- a/src/chat/status_state.rs
+++ b/src/chat/status_state.rs
@@ -1,0 +1,129 @@
+//! Persistent state for the bot's live-status messages (Phase 2).
+//!
+//! For each telescope that has a status message pinned in its channel we
+//! remember the `(channel_id, message_id)` pair so subsequent poll cycles
+//! can edit the same message in place rather than spamming the channel
+//! with fresh posts. Stored at `chat.discord_bot.state_file` (default
+//! `./spacecat-state.json`).
+//!
+//! Atomic writes: serialize to a tempfile alongside the target, then
+//! rename in place. A crash during write leaves the previous valid file
+//! intact.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct StatusMessage {
+    pub channel_id: u64,
+    pub message_id: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatusState {
+    /// telescope name -> live status message reference
+    #[serde(default)]
+    pub status_messages: HashMap<String, StatusMessage>,
+}
+
+impl StatusState {
+    /// Load state from `path`. Returns `Default` when the file is missing
+    /// (first run). Other I/O or parse errors propagate.
+    pub fn load(path: &Path) -> io::Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str(&content).map_err(io::Error::other),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Atomic save: write to `<path>.tmp` then rename to `path`. The
+    /// rename is atomic on POSIX and on Windows for files in the same
+    /// directory.
+    pub fn save(&self, path: &Path) -> io::Result<()> {
+        let json = serde_json::to_string_pretty(self).map_err(io::Error::other)?;
+        let mut temp: PathBuf = path.to_path_buf();
+        let fname = path
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "state".to_string());
+        temp.set_file_name(format!(".{fname}.tmp"));
+        fs::write(&temp, json)?;
+        fs::rename(&temp, path)?;
+        Ok(())
+    }
+
+    pub fn get(&self, telescope: &str) -> Option<StatusMessage> {
+        self.status_messages.get(telescope).copied()
+    }
+
+    pub fn set(&mut self, telescope: &str, message: StatusMessage) {
+        self.status_messages.insert(telescope.to_string(), message);
+    }
+
+    pub fn remove(&mut self, telescope: &str) {
+        self.status_messages.remove(telescope);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    fn tmp_path(suffix: &str) -> PathBuf {
+        let mut p = env::temp_dir();
+        p.push(format!(
+            "spacecat-status-{}-{}.json",
+            std::process::id(),
+            suffix
+        ));
+        p
+    }
+
+    #[test]
+    fn test_load_missing_returns_default() {
+        let p = tmp_path("missing");
+        let _ = fs::remove_file(&p);
+        let state = StatusState::load(&p).unwrap();
+        assert!(state.status_messages.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_roundtrip() {
+        let p = tmp_path("roundtrip");
+        let mut state = StatusState::default();
+        state.set(
+            "c925",
+            StatusMessage {
+                channel_id: 111,
+                message_id: 999,
+            },
+        );
+        state.save(&p).unwrap();
+
+        let loaded = StatusState::load(&p).unwrap();
+        let m = loaded.get("c925").unwrap();
+        assert_eq!(m.channel_id, 111);
+        assert_eq!(m.message_id, 999);
+        let _ = fs::remove_file(&p);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut state = StatusState::default();
+        state.set(
+            "a",
+            StatusMessage {
+                channel_id: 1,
+                message_id: 2,
+            },
+        );
+        assert!(state.get("a").is_some());
+        state.remove("a");
+        assert!(state.get("a").is_none());
+    }
+}

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -223,12 +223,10 @@ impl ChatUpdater {
 
         if let Some(target) = &self.state.current_target {
             message = message.field("Target", &target.name, false);
-            if let Some(coords) = &target.coordinates {
-                message = message.field(
-                    "Coordinates",
-                    &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                    false,
-                );
+            if let Some(coords) = &target.coordinates
+                && let Some(s) = coords.display()
+            {
+                message = message.field("Coordinates", &s, false);
             }
         }
 
@@ -822,12 +820,10 @@ impl ChatUpdater {
                 message = message.field("Project", project, true);
             }
 
-            if let Some(coords) = &target.coordinates {
-                message = message.field(
-                    "Coordinates",
-                    &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                    false,
-                );
+            if let Some(coords) = &target.coordinates
+                && let Some(s) = coords.display()
+            {
+                message = message.field("Coordinates", &s, false);
             }
 
             if let Some(rotation) = &target.rotation {
@@ -944,12 +940,10 @@ impl ChatUpdater {
             message = message.field("Project", project, true);
         }
 
-        if let Some(coords) = &new_target.coordinates {
-            message = message.field(
-                "Coordinates",
-                &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                false,
-            );
+        if let Some(coords) = &new_target.coordinates
+            && let Some(s) = coords.display()
+        {
+            message = message.field("Coordinates", &s, false);
         }
 
         if let Some(rotation) = &new_target.rotation {
@@ -972,12 +966,10 @@ impl ChatUpdater {
             message = message.field("Project", project, true);
         }
 
-        if let Some(coords) = &target.coordinates {
-            message = message.field(
-                "Coordinates",
-                &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                false,
-            );
+        if let Some(coords) = &target.coordinates
+            && let Some(s) = coords.display()
+        {
+            message = message.field("Coordinates", &s, false);
         }
 
         if let Some(rotation) = &target.rotation {
@@ -1142,12 +1134,10 @@ impl ChatUpdater {
 
         if let Some(target) = &self.state.current_target {
             message = message.field("Current Target", &target.name, true);
-            if let Some(coords) = &target.coordinates {
-                message = message.field(
-                    "Coordinates",
-                    &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
-                    false,
-                );
+            if let Some(coords) = &target.coordinates
+                && let Some(s) = coords.display()
+            {
+                message = message.field("Coordinates", &s, false);
             }
         }
 

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -903,38 +903,39 @@ impl ChatUpdater {
             position_change.to_string()
         };
 
-        let message = ChatMessage::new(&self.titled(format!("{success_indicator} Autofocus Completed")))
-            .color(color)
-            .field("Filter", &af_data.filter, true)
-            .field("Method", &af_data.method, true)
-            .field("Duration", &af_data.duration, true)
-            .field(
-                "Temperature",
-                &format!("{:.1}°C", af_data.temperature),
-                true,
-            )
-            .field(
-                "Focus Position",
-                &af_data.calculated_focus_point.position.to_string(),
-                true,
-            )
-            .field("Position Change", &position_change_text, true)
-            .field(
-                "HFR",
-                &format!("{:.3}", af_data.calculated_focus_point.value),
-                true,
-            )
-            .field(
-                "R-squared",
-                &format!("{:.4}", af.get_best_r_squared()),
-                true,
-            )
-            .field(
-                "Measurements",
-                &af_data.measure_points.len().to_string(),
-                true,
-            )
-            .footer(&format!("Focuser: {}", af_data.auto_focuser_name));
+        let message =
+            ChatMessage::new(&self.titled(format!("{success_indicator} Autofocus Completed")))
+                .color(color)
+                .field("Filter", &af_data.filter, true)
+                .field("Method", &af_data.method, true)
+                .field("Duration", &af_data.duration, true)
+                .field(
+                    "Temperature",
+                    &format!("{:.1}°C", af_data.temperature),
+                    true,
+                )
+                .field(
+                    "Focus Position",
+                    &af_data.calculated_focus_point.position.to_string(),
+                    true,
+                )
+                .field("Position Change", &position_change_text, true)
+                .field(
+                    "HFR",
+                    &format!("{:.3}", af_data.calculated_focus_point.value),
+                    true,
+                )
+                .field(
+                    "R-squared",
+                    &format!("{:.4}", af.get_best_r_squared()),
+                    true,
+                )
+                .field(
+                    "Measurements",
+                    &af_data.measure_points.len().to_string(),
+                    true,
+                )
+                .footer(&format!("Focuser: {}", af_data.auto_focuser_name));
 
         self.chat_manager
             .send_message(&message, &self.chat_target)
@@ -1065,9 +1066,10 @@ impl ChatUpdater {
         let color = get_event_color(&event.event);
         let title = get_event_title(&event.event);
 
-        let mut message = ChatMessage::new(&self.titled(title))
-            .color(color)
-            .field("Time", &event.time, false);
+        let mut message =
+            ChatMessage::new(&self.titled(title))
+                .color(color)
+                .field("Time", &event.time, false);
 
         // Add event-specific details
         if let Some(details) = &event.details {

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -48,6 +48,10 @@ struct UpdaterState {
     sequence_running: bool,
     /// Active TS-WAITSTART wait-end time, if NINA is currently waiting.
     wait_until: Option<DateTime<FixedOffset>>,
+    /// Fingerprint of the last live-status embed posted. Lets us skip the
+    /// `upsert_status` call when nothing meaningful has changed since the
+    /// previous poll cycle.
+    last_status_fingerprint: Option<String>,
 }
 
 impl UpdaterState {
@@ -65,7 +69,39 @@ impl UpdaterState {
             last_guider_event: None,
             sequence_running: false,
             wait_until: None,
+            last_status_fingerprint: None,
         }
+    }
+
+    /// Fingerprint of the state that should drive a live-status edit.
+    /// Deliberately excludes the live mount RA/Dec — those drift every
+    /// cycle during tracking and would force constant edits. We only
+    /// re-render when discrete state transitions happen (target changes,
+    /// filter switches, mount events, guider events, wait timers, etc.).
+    fn status_fingerprint(&self) -> String {
+        let target = self
+            .current_target
+            .as_ref()
+            .map(|t| t.name.as_str())
+            .unwrap_or("");
+        let filter = self
+            .last_filter
+            .as_ref()
+            .map(|f| f.name.as_str())
+            .unwrap_or("");
+        let mount = self.last_mount_event.as_deref().unwrap_or("");
+        let guider = self.last_guider_event.as_deref().unwrap_or("");
+        let waiting = self.wait_until.is_some();
+        // Round the meridian-flip ETA to whole minutes; second-by-second
+        // drift shouldn't trigger an edit.
+        let flip_minutes = self
+            .meridian_flip_time
+            .map(|h| (h * 60.0).round() as i64)
+            .unwrap_or(-1);
+        format!(
+            "t={target}|f={filter}|m={mount}|g={guider}|w={waiting}|sr={}|flip={flip_minutes}",
+            self.sequence_running
+        )
     }
 
     fn event_key(event: &Event) -> String {
@@ -156,15 +192,21 @@ impl ChatUpdater {
 
     /// Build a live-status embed from current state and push it to any
     /// service that supports editing in place (currently only the Discord
-    /// bot). No-op for telescopes routed only through webhooks/Matrix.
-    async fn refresh_status_message(&self) {
+    /// bot). No-op for telescopes routed only through webhooks/Matrix, or
+    /// when the state fingerprint hasn't changed since the last cycle.
+    async fn refresh_status_message(&mut self) {
         if !self.chat_manager.has_status_upsert(&self.chat_target) {
+            return;
+        }
+        let fingerprint = self.state.status_fingerprint();
+        if self.state.last_status_fingerprint.as_ref() == Some(&fingerprint) {
             return;
         }
         let message = self.build_status_message().await;
         self.chat_manager
             .upsert_status(&self.telescope_name, &self.chat_target, &message)
             .await;
+        self.state.last_status_fingerprint = Some(fingerprint);
     }
 
     /// Compose the live-status `ChatMessage`. Pulls cheap state from
@@ -1162,6 +1204,11 @@ impl ChatUpdater {
                 EventDetails::WaitStart { wait_end_time } => {
                     message = message.field("Wait Until", wait_end_time, false);
                 }
+                EventDetails::AutofocusPointAdded { position, hfr } => {
+                    message = message
+                        .field("Position", &position.to_string(), true)
+                        .field("HFR", &format!("{hfr:.3}"), true);
+                }
             }
         }
 
@@ -1313,6 +1360,7 @@ fn get_event_color(event: &str) -> u32 {
         event_types::FOCUSER_USER_FOCUSED => colors::PURPLE,
         event_types::AUTOFOCUS_STARTING => colors::PURPLE,
         event_types::AUTOFOCUS_FINISHED => colors::PURPLE,
+        event_types::AUTOFOCUS_POINT_ADDED => colors::PURPLE,
         event_types::ERROR_AF => colors::RED,
 
         // Rotator events
@@ -1364,6 +1412,7 @@ fn get_event_title(event: &str) -> String {
         event_types::FILTERWHEEL_CHANGED => "🔄 Filter Changed".to_string(),
         event_types::TS_TARGETSTART => "🎯 Target Started".to_string(),
         event_types::TS_WAITSTART => "⏳ Sequence Waiting".to_string(),
+        event_types::AUTOFOCUS_POINT_ADDED => "📈 Autofocus Point".to_string(),
         _ => format!("📡 {}", event),
     }
 }

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -149,8 +149,75 @@ impl ChatUpdater {
             self.poll_sequence().await;
             self.poll_events().await;
             self.poll_images().await;
+            self.refresh_status_message().await;
             sleep(poll_interval).await;
         }
+    }
+
+    /// Build a live-status embed from current state and push it to any
+    /// service that supports editing in place (currently only the Discord
+    /// bot). No-op for telescopes routed only through webhooks/Matrix.
+    async fn refresh_status_message(&self) {
+        if !self.chat_manager.has_status_upsert(&self.chat_target) {
+            return;
+        }
+        let message = self.build_status_message().await;
+        self.chat_manager
+            .upsert_status(&self.telescope_name, &self.chat_target, &message)
+            .await;
+    }
+
+    /// Compose the live-status `ChatMessage`. Pulls cheap state from
+    /// `self.state` and adds a fresh mount snapshot per cycle (the most
+    /// useful single fetch for at-a-glance status).
+    async fn build_status_message(&self) -> ChatMessage {
+        let mut message = ChatMessage::new(&self.titled("📡 Live status"));
+        message = message.color(colors::CYAN);
+
+        let summary = self.format_startup_status();
+        if !summary.is_empty() {
+            message = message.field("State", &summary, false);
+        }
+
+        if let Some(target) = &self.state.current_target {
+            message = message.field("Target", &target.name, false);
+            if let Some(coords) = &target.coordinates {
+                message = message.field(
+                    "Coordinates",
+                    &format!("RA: {}\nDec: {}", coords.ra_string, coords.dec_string),
+                    false,
+                );
+            }
+        }
+
+        if let Some(filter) = &self.state.last_filter
+            && !filter.is_unknown()
+        {
+            message = message.field("Filter", &filter.name, true);
+        }
+
+        if let Some(flip_hours) = self.state.meridian_flip_time {
+            message = message.field(
+                "Meridian flip in",
+                &meridian_flip_time_formatted_with_clock(flip_hours),
+                true,
+            );
+        }
+
+        // Fresh mount snapshot — small payload, very useful at a glance.
+        if let Ok(mount_info) = self.client.get_mount_info().await
+            && mount_info.is_connected()
+        {
+            let (ra, dec) = mount_info.get_coordinates();
+            message = message
+                .field("Mount RA/Dec", &format!("RA: {ra}\nDec: {dec}"), true)
+                .field("Pier", mount_info.get_side_of_pier(), true);
+        }
+
+        message.footer(&format!(
+            "Updated {}",
+            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        ))
     }
 
     pub async fn initialize_baseline(&mut self) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,15 +301,10 @@ impl Config {
     /// telescope, returns it. Otherwise returns an error listing the names.
     pub fn pick_telescope(&self, name: Option<&str>) -> Result<&TelescopeConfig, String> {
         match (name, self.telescopes.as_slice()) {
-            (Some(n), _) => self
-                .telescopes
-                .iter()
-                .find(|t| t.name == n)
-                .ok_or_else(|| {
-                    let known: Vec<&str> =
-                        self.telescopes.iter().map(|t| t.name.as_str()).collect();
-                    format!("Telescope '{n}' not found. Known telescopes: {known:?}")
-                }),
+            (Some(n), _) => self.telescopes.iter().find(|t| t.name == n).ok_or_else(|| {
+                let known: Vec<&str> = self.telescopes.iter().map(|t| t.name.as_str()).collect();
+                format!("Telescope '{n}' not found. Known telescopes: {known:?}")
+            }),
             (None, [only]) => Ok(only),
             (None, []) => Err("No telescopes configured.".to_string()),
             (None, many) => {
@@ -368,6 +363,15 @@ impl Config {
             );
         }
 
+        if let Some(bot) = &self.chat.discord_bot
+            && bot.enabled
+            && bot.token.is_empty()
+        {
+            return Err(
+                "Discord bot token cannot be empty when chat.discord_bot is enabled".to_string(),
+            );
+        }
+
         let mut seen = std::collections::HashSet::new();
         for t in &self.telescopes {
             if !seen.insert(t.name.clone()) {
@@ -396,7 +400,7 @@ impl TelescopeConfig {
 
         if !self.api.base_url.starts_with("http://") && !self.api.base_url.starts_with("https://") {
             return Err(ctx(
-                "API base URL must start with http:// or https://".to_string(),
+                "API base URL must start with http:// or https://".to_string()
             ));
         }
 
@@ -406,7 +410,7 @@ impl TelescopeConfig {
 
         if self.api.timeout_seconds > 300 {
             return Err(ctx(
-                "Timeout seconds should not exceed 300 (5 minutes)".to_string(),
+                "Timeout seconds should not exceed 300 (5 minutes)".to_string()
             ));
         }
 
@@ -437,6 +441,15 @@ impl TelescopeConfig {
         {
             return Err(ctx(
                 "matrix_room_id override set but shared chat.matrix is not enabled".to_string(),
+            ));
+        }
+
+        if let Some(_channel) = &self.chat.discord_channel_id
+            && shared_chat.discord_bot.as_ref().is_none_or(|b| !b.enabled)
+        {
+            return Err(ctx(
+                "discord_channel_id override set but shared chat.discord_bot is not enabled"
+                    .to_string(),
             ));
         }
 
@@ -510,7 +523,10 @@ mod tests {
         let config: Config = serde_json::from_str(json).unwrap();
         assert_eq!(config.telescopes.len(), 1);
         assert_eq!(config.telescopes[0].name, "default");
-        assert_eq!(config.telescopes[0].api.base_url, "http://192.168.0.81:1888");
+        assert_eq!(
+            config.telescopes[0].api.base_url,
+            "http://192.168.0.81:1888"
+        );
         // Legacy `chat.discord.webhook_url` is aliased into the new shared
         // default location.
         let discord = config.chat.discord.as_ref().unwrap();
@@ -519,7 +535,10 @@ mod tests {
             Some("https://discord.com/api/webhooks/123/abc")
         );
         let matrix = config.chat.matrix.as_ref().unwrap();
-        assert_eq!(matrix.default_room_id.as_deref(), Some("!legacy:example.com"));
+        assert_eq!(
+            matrix.default_room_id.as_deref(),
+            Some("!legacy:example.com")
+        );
         // No per-telescope overrides set.
         assert!(config.telescopes[0].chat.discord_webhook_url.is_none());
         assert!(config.telescopes[0].chat.matrix_room_id.is_none());
@@ -593,6 +612,68 @@ mod tests {
         let config = Config::default();
         // Single telescope, no name -> ok
         assert_eq!(config.pick_telescope(None).unwrap().name, "default");
+    }
+
+    #[test]
+    fn test_discord_bot_config_parses() {
+        let json = r#"{
+            "chat": {
+                "discord_bot": {
+                    "enabled": true,
+                    "token": "abc",
+                    "default_channel_id": 12345,
+                    "write_acl": [111, 222]
+                }
+            },
+            "telescopes": [
+                {
+                    "name": "c925",
+                    "api": { "base_url": "http://a", "timeout_seconds": 30, "retry_attempts": 3 },
+                    "chat": { "discord_channel_id": 67890 }
+                }
+            ]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let bot = config.chat.discord_bot.as_ref().unwrap();
+        assert!(bot.enabled);
+        assert_eq!(bot.token, "abc");
+        assert_eq!(bot.default_channel_id, Some(12345));
+        assert_eq!(bot.write_acl, vec![111, 222]);
+        assert_eq!(bot.state_file, "./spacecat-state.json");
+        assert_eq!(config.telescopes[0].chat.discord_channel_id, Some(67890));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_channel_id_without_bot_enabled_rejected() {
+        let json = r#"{
+            "telescopes": [
+                {
+                    "name": "c925",
+                    "api": { "base_url": "http://a", "timeout_seconds": 30, "retry_attempts": 3 },
+                    "chat": { "discord_channel_id": 67890 }
+                }
+            ]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("discord_channel_id"));
+        assert!(err.contains("discord_bot"));
+    }
+
+    #[test]
+    fn test_bot_enabled_without_token_rejected() {
+        let json = r#"{
+            "chat": {
+                "discord_bot": { "enabled": true, "token": "" }
+            },
+            "telescopes": [
+                { "name": "c925", "api": { "base_url": "http://a", "timeout_seconds": 30, "retry_attempts": 3 } }
+            ]
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("token"));
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -103,15 +103,67 @@ fn de_filter_id<'de, D: Deserializer<'de>>(d: D) -> Result<i32, D::Error> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct TargetCoordinates {
-    #[serde(rename = "RA")]
+    // TS-TARGETSTART events on c925 (and likely elsewhere) sometimes ship
+    // every Coordinates field as an empty array when the target lacks
+    // coords — same NINA quirk that produces empty `FilterInfo`. Each
+    // field accepts `[]` and falls back to a sentinel; the whole struct
+    // remains parseable so the target name + project still survive.
+    #[serde(rename = "RA", deserialize_with = "de_f64_or_empty")]
     pub ra: f64,
+    #[serde(deserialize_with = "de_f64_or_empty")]
     pub dec: f64,
-    #[serde(rename = "RAString")]
+    #[serde(rename = "RAString", deserialize_with = "de_string_or_empty")]
     pub ra_string: String,
+    #[serde(deserialize_with = "de_string_or_empty")]
     pub dec_string: String,
+    #[serde(deserialize_with = "de_string_or_empty")]
     pub epoch: String,
-    #[serde(rename = "RADegrees")]
+    #[serde(rename = "RADegrees", deserialize_with = "de_f64_or_empty")]
     pub ra_degrees: f64,
+}
+
+impl TargetCoordinates {
+    /// True when every coord field came back as the empty-array sentinel
+    /// (NINA's "unknown" shape). Display sites should suppress the
+    /// Coordinates field in this case.
+    pub fn is_unknown(&self) -> bool {
+        self.ra_string.is_empty() && self.dec_string.is_empty() && self.ra.is_nan()
+    }
+
+    /// `"RA: ...\nDec: ..."` if the coords are known, otherwise None.
+    pub fn display(&self) -> Option<String> {
+        if self.is_unknown() {
+            None
+        } else {
+            Some(format!("RA: {}\nDec: {}", self.ra_string, self.dec_string))
+        }
+    }
+}
+
+fn de_string_or_empty<'de, D: Deserializer<'de>>(d: D) -> Result<String, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Array(a) if a.is_empty() => Ok(String::new()),
+        other => Err(D::Error::custom(format!(
+            "expected string or [] for coordinate field, got {other}"
+        ))),
+    }
+}
+
+fn de_f64_or_empty<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("coordinate not f64")),
+        serde_json::Value::Array(a) if a.is_empty() => Ok(f64::NAN),
+        other => Err(D::Error::custom(format!(
+            "expected number or [] for coordinate field, got {other}"
+        ))),
+    }
 }
 
 // Event type constants for easier matching.
@@ -435,6 +487,40 @@ mod tests {
                 assert_eq!(new.id, -1);
             }
             other => panic!("expected FilterWheelChange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_ts_targetstart_with_empty_array_coords() {
+        // c925 emits TS-TARGETSTART with empty-array coord fields when the
+        // target lacks coords. The struct should still parse and surface
+        // the target name + project name.
+        let event_json = r#"{
+            "Time": "2026-05-19T05:40:29.6220877",
+            "Coordinates": {
+                "RA": [], "Dec": [], "RAString": [], "DecString": [],
+                "Epoch": [], "RADegrees": []
+            },
+            "TargetEndTime": "2026-05-19T04:00:28.7026313",
+            "ProjectName": "Sunflower Galaxy",
+            "Event": "TS-TARGETSTART",
+            "TargetName": "Sunflower Galaxy",
+            "Rotation": 0
+        }"#;
+        let event: Event = serde_json::from_str(event_json).unwrap();
+        match event.details {
+            Some(EventDetails::TargetStart {
+                target_name,
+                project_name,
+                coordinates,
+                ..
+            }) => {
+                assert_eq!(target_name, "Sunflower Galaxy");
+                assert_eq!(project_name, "Sunflower Galaxy");
+                assert!(coordinates.is_unknown());
+                assert!(coordinates.ra_string.is_empty());
+            }
+            other => panic!("expected TargetStart, got {other:?}"),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -45,6 +45,15 @@ pub enum EventDetails {
         #[serde(rename = "WaitEndTime")]
         wait_end_time: String,
     },
+    /// Autofocus measurement point. NINA emits these in flurries (~one per
+    /// step) during an autofocus run, each carrying the focuser position
+    /// and the half-flux radius measured at that position.
+    AutofocusPointAdded {
+        #[serde(rename = "Position")]
+        position: i32,
+        #[serde(rename = "HFR")]
+        hfr: f64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -426,6 +435,25 @@ mod tests {
                 assert_eq!(new.id, -1);
             }
             other => panic!("expected FilterWheelChange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_autofocus_point_added_event() {
+        let event_json = r#"{
+            "Position": 3325,
+            "Time": "2026-05-18T22:43:41.8412779-07:00",
+            "HFR": 4.3494099367270405,
+            "Event": "AUTOFOCUS-POINT-ADDED"
+        }"#;
+        let event: Event = serde_json::from_str(event_json).unwrap();
+        assert_eq!(event.event, event_types::AUTOFOCUS_POINT_ADDED);
+        match event.details {
+            Some(EventDetails::AutofocusPointAdded { position, hfr }) => {
+                assert_eq!(position, 3325);
+                assert!((hfr - 4.3494099367270405).abs() < 1e-9);
+            }
+            other => panic!("expected AutofocusPointAdded, got {other:?}"),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1088,6 +1088,9 @@ fn display_last_events(events: &EventHistoryResponse, count: usize) {
                 EventDetails::WaitStart { wait_end_time } => {
                     println!("  Details: Waiting until {}", wait_end_time);
                 }
+                EventDetails::AutofocusPointAdded { position, hfr } => {
+                    println!("  Details: Autofocus point — position {position}, HFR {hfr:.3}");
+                }
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1079,10 +1079,9 @@ fn display_last_events(events: &EventHistoryResponse, count: usize) {
                 } => {
                     println!("  Details: Target started: {}", target_name);
                     println!("    Project: {}", project_name);
-                    println!(
-                        "    Coordinates: {} {}",
-                        coordinates.ra_string, coordinates.dec_string
-                    );
+                    if let Some(s) = coordinates.display() {
+                        println!("    Coordinates: {}", s.replace('\n', " "));
+                    }
                     println!("    Rotation: {}°", rotation);
                 }
                 EventDetails::WaitStart { wait_end_time } => {

--- a/src/service_wrapper.rs
+++ b/src/service_wrapper.rs
@@ -1,10 +1,11 @@
 //! Service wrapper abstraction for running SpaceCat as CLI or background service
 
 use crate::api::SpaceCatApiClient;
-use crate::chat::{ChatConfig, ChatServiceManager, DiscordChatService, MatrixChatService};
+use crate::chat::{ChatServiceManager, DiscordChatService, MatrixChatService, run_bot};
 use crate::chat_updater::ChatUpdater;
 use crate::config::{Config, TelescopeConfig};
 use crate::error::{ChatError, ServiceError, ServiceResult, SpaceCatError};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -19,8 +20,9 @@ impl ServiceWrapper {
     }
 
     /// Run chat updaters for all configured telescopes concurrently. The
-    /// shared `ChatServiceManager` (one Matrix login, one Discord client) is
-    /// built once and shared by reference across every telescope task.
+    /// shared `ChatServiceManager` (one Matrix login, one Discord client,
+    /// one Discord bot) is built once and shared by reference across every
+    /// telescope task.
     pub async fn run_cli(&self, interval: u64) -> ServiceResult<()> {
         if self.config.telescopes.is_empty() {
             return Err(ServiceError::Initialization {
@@ -28,13 +30,13 @@ impl ServiceWrapper {
             });
         }
 
-        let chat_manager = Arc::new(
-            build_shared_chat_manager(&self.config.chat)
-                .await
-                .map_err(|e| ServiceError::Initialization {
+        let (chat_manager, _bot_join) =
+            build_shared_chat_manager(&self.config).await.map_err(|e| {
+                ServiceError::Initialization {
                     reason: e.to_string(),
-                })?,
-        );
+                }
+            })?;
+        let chat_manager = Arc::new(chat_manager);
 
         let poll_interval = Duration::from_secs(interval);
         let mut handles = Vec::new();
@@ -46,10 +48,7 @@ impl ServiceWrapper {
                     Ok(mut updater) => {
                         updater.start_polling(poll_interval).await;
                     }
-                    Err(e) => eprintln!(
-                        "[{}] Failed to create chat updater: {e}",
-                        telescope.name
-                    ),
+                    Err(e) => eprintln!("[{}] Failed to create chat updater: {e}", telescope.name),
                 }
             });
             handles.push(handle);
@@ -67,18 +66,23 @@ impl ServiceWrapper {
     }
 }
 
-/// Build the process-wide chat manager from the shared chat block. Matrix
-/// logs in once here, regardless of how many telescopes are configured.
+/// Build the process-wide chat manager. Matrix logs in once, the Discord
+/// bot connects once, regardless of how many telescopes are configured.
+///
+/// Returns `(manager, bot_gateway_join)`. The bot gateway join handle keeps
+/// the bot task alive for the life of the process; drop it to detach.
 pub async fn build_shared_chat_manager(
-    chat: &ChatConfig,
-) -> Result<ChatServiceManager, SpaceCatError> {
+    config: &Config,
+) -> Result<(ChatServiceManager, Option<tokio::task::JoinHandle<()>>), SpaceCatError> {
+    let chat = &config.chat;
     let mut manager = ChatServiceManager::new();
+    let mut bot_join: Option<tokio::task::JoinHandle<()>> = None;
 
     if let Some(discord) = &chat.discord
         && discord.enabled
     {
         println!(
-            "Initializing shared Discord chat service (default webhook: {})...",
+            "Initializing shared Discord webhook service (default webhook: {})...",
             if discord.default_webhook_url.is_some() {
                 "configured"
             } else {
@@ -110,11 +114,48 @@ pub async fn build_shared_chat_manager(
         manager.add_service(Box::new(service));
     }
 
+    if let Some(bot_config) = &chat.discord_bot
+        && bot_config.enabled
+    {
+        println!(
+            "Initializing shared Discord bot (state file: {})...",
+            bot_config.state_file
+        );
+
+        // Build the per-telescope API client map and the channel routing
+        // table the bot needs for slash commands. Warn (don't error) if a
+        // telescope has both a channel_id and a webhook_url — the channel
+        // takes precedence and the webhook is ignored.
+        let mut api_clients = HashMap::new();
+        let mut channel_to_telescope = HashMap::new();
+        for telescope in &config.telescopes {
+            let client =
+                SpaceCatApiClient::new(telescope.api.clone()).map_err(SpaceCatError::Api)?;
+            api_clients.insert(telescope.name.clone(), client);
+            if let Some(channel_id) = telescope.chat.discord_channel_id {
+                channel_to_telescope.insert(channel_id, telescope.name.clone());
+                if telescope.chat.discord_webhook_url.is_some() {
+                    eprintln!(
+                        "[{}] Warning: both discord_channel_id and discord_webhook_url \
+                         configured; webhook will be ignored (bot takes precedence).",
+                        telescope.name
+                    );
+                }
+            }
+        }
+
+        let (service, join) = run_bot(bot_config, api_clients, channel_to_telescope)
+            .await
+            .map_err(SpaceCatError::Chat)?;
+        manager.add_service(Box::new(service));
+        bot_join = Some(join);
+    }
+
     if manager.service_count() == 0 {
         println!("Warning: No chat services configured. Running in monitoring-only mode.");
     }
 
-    Ok(manager)
+    Ok((manager, bot_join))
 }
 
 /// Construct a `ChatUpdater` for one telescope, wired to the shared manager.
@@ -145,18 +186,18 @@ mod windows_service_impl {
                 reason: format!("Failed to create Tokio runtime: {}", e),
             })?;
 
+            let config = self.config.clone();
             let telescopes = self.config.telescopes.clone();
-            let chat_config = self.config.chat.clone();
             let poll_interval = Duration::from_secs(5);
 
             rt.block_on(async move {
-                let chat_manager = Arc::new(
-                    build_shared_chat_manager(&chat_config)
-                        .await
-                        .map_err(|e| ServiceError::Initialization {
+                let (manager, _bot_join) =
+                    build_shared_chat_manager(&config).await.map_err(|e| {
+                        ServiceError::Initialization {
                             reason: format!("Failed to build chat manager: {}", e),
-                        })?,
-                );
+                        }
+                    })?;
+                let chat_manager = Arc::new(manager);
 
                 let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                 {
@@ -177,10 +218,7 @@ mod windows_service_impl {
                             match build_chat_updater(telescope.clone(), chat_manager).await {
                                 Ok(u) => u,
                                 Err(e) => {
-                                    eprintln!(
-                                        "[{}] Failed to initialize: {e}",
-                                        telescope.name
-                                    );
+                                    eprintln!("[{}] Failed to initialize: {e}", telescope.name);
                                     return;
                                 }
                             };


### PR DESCRIPTION
## Summary

Phases 1–3 of the Discord bot rollout (see `DISCORD_BOT_PLAN.md` for the full roadmap; Phase 4 deferred).

**Phase 1 — bot infrastructure + read commands**
- New `DiscordBotService` (Serenity + Poise) coexists with the existing webhook path. One bot token, one gateway connection, every telescope.
- Per-telescope opt-in via `chat.discord_channel_id`. When set, the webhook service yields and the bot posts to that channel.
- 9 read-only slash commands under a single `/spacecat` namespace: `status`, `sequence`, `target`, `mount`, `filter`, `focus`, `guider`, `events`, `last-image`. Channel-driven default with `telescope:<name>` override.

**Phase 2 — opt-in live status + change detection**
- `chat.discord_bot.live_status: bool` (default false) toggles a pinned status embed per bot-routed telescope, edited in place.
- State persisted to `chat.discord_bot.state_file` (default `./spacecat-state.json`) so the same message survives restarts. Atomic save via tempfile + rename. If the message is deleted (404), repost + update state.
- `ChatUpdater` caches a fingerprint over discrete state fields (target, filter, mount/guider events, sequence_running, wait state, flip ETA rounded to minutes). Upsert is skipped when nothing changed — RA/Dec drift during tracking doesn't cause an edit storm.

**Phase 3 — ACL-gated write commands**
- Write commands check the invoker's Discord user ID against `chat.discord_bot.write_acl`. Unauthorized invocations get an ephemeral reject.
- Destructive actions additionally require a Confirm/Cancel button click within 30s before the API fires.
- `SpaceCatApiClient::execute_command` issues a single GET (NINA's write surface is all GETs with query params) without retry — most operations aren't safely idempotent.

| Command | Endpoint | Destructive |
|---|---|---|
| `/spacecat unpark` | `/equipment/mount/unpark` | |
| `/spacecat home` | `/equipment/mount/home` | |
| `/spacecat change-filter <name>` | `/equipment/filterwheel/change-filter?filterId=N` | |
| `/spacecat guider-start [calibrate]` | `/equipment/guider/start` | |
| `/spacecat guider-stop` | `/equipment/guider/stop` | |
| `/spacecat cool <temp> [minutes]` | `/equipment/camera/cool` | |
| `/spacecat warm [minutes]` | `/equipment/camera/warm` | |
| `/spacecat park` | `/equipment/mount/park` | ✓ confirm |
| `/spacecat abort-capture` | `/equipment/camera/abort-exposure` | ✓ confirm |
| `/spacecat stop-sequence` | `/sequence/stop` | ✓ confirm |
| `/spacecat start-sequence [skip-validation]` | `/sequence/start` | ✓ confirm |

`change-filter` resolves filter names ("L", "HA", etc.) against the live filterwheel info — no need to remember numeric IDs.

## Side fixes shipped in this PR

- **`AUTOFOCUS-POINT-ADDED` enrichment**: NINA ships `{Position, HFR}` inline; new `EventDetails::AutofocusPointAdded` variant surfaces them in console + Discord notifications.
- **Tolerate empty-array `TargetCoordinates`**: c925 emits TS-TARGETSTART with every coord field as `[]` when coords are unavailable. The whole `TargetStart` variant was failing to parse, dropping the target name. Now parses correctly (verified against c925, target now shows as "Sunflower Galaxy" instead of "Sequential Instruction Set"). Coordinate display sites suppress the field when unknown.

## Test plan

- [x] `cargo build`, `cargo test` (49 lib tests pass — covers config, status state, target-coords-empty-array, autofocus point parsing), `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check` all clean
- [x] Existing webhook-only setups unchanged
- [x] Live Phase 1 + 2 against c925: bot connected, read commands present in autocomplete after global registration, status embed posted + persisted, change-detection prevents redundant edits
- [x] Target name fix verified against live c925 events ("Sunflower Galaxy" replaces the generic container name)
- [ ] Live Phase 3: invoke `/spacecat park` as authorized user, confirm button works, mount actually parks. Invoke as unauthorized user, get the ACL reject. Try a non-destructive write (e.g. `/spacecat change-filter L`) end-to-end.

## Deferred to Phase 4

- Bot presence (`Watching N telescopes`)
- Per-guild command registration for faster dev iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)