### PR TITLE
events: enrich rotator + focuser events

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,9 +2,11 @@ use crate::autofocus::AutofocusResponse;
 use crate::config::ApiConfig;
 use crate::events::EventHistoryResponse;
 use crate::filterwheel::FilterWheelInfoResponse;
+use crate::focuser::FocuserInfoResponse;
 use crate::guider::GuiderInfoResponse;
 use crate::images::{ImageHistoryResponse, ImageResponse, ThumbnailResponse};
 use crate::mount::MountInfoResponse;
+use crate::rotator::RotatorInfoResponse;
 use crate::sequence::SequenceResponse;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -364,6 +366,18 @@ impl SpaceCatApiClient {
     /// Fetch current guider state from the /equipment/guider/info endpoint
     pub async fn get_guider_info(&self) -> Result<GuiderInfoResponse, ApiError> {
         self.generic_request_with_retry("/equipment/guider/info", &[])
+            .await
+    }
+
+    /// Fetch current rotator state from the /equipment/rotator/info endpoint
+    pub async fn get_rotator_info(&self) -> Result<RotatorInfoResponse, ApiError> {
+        self.generic_request_with_retry("/equipment/rotator/info", &[])
+            .await
+    }
+
+    /// Fetch current focuser state from the /equipment/focuser/info endpoint
+    pub async fn get_focuser_info(&self) -> Result<FocuserInfoResponse, ApiError> {
+        self.generic_request_with_retry("/equipment/focuser/info", &[])
             .await
     }
 

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -475,6 +475,8 @@ impl ChatUpdater {
             event_types::SEQUENCE_STARTING | event_types::SEQUENCE_FINISHED => {
                 self.handle_sequence_event(event).await
             }
+            event_types::ROTATOR_SYNCED => self.handle_rotator_synced(event).await,
+            event_types::FOCUSER_USER_FOCUSED => self.handle_focuser_user_focused(event).await,
             event_types::IMAGE_SAVE => {} // Handled in image polling
             _ => self.handle_generic_event(event).await,
         }
@@ -645,6 +647,29 @@ impl ChatUpdater {
         // Use the freshest sequence we have. The poll_sequence loop refreshes
         // this every cycle, so it's typically <interval seconds stale.
         self.send_sequence_event_notification(event).await;
+    }
+
+    /// ROTATOR-SYNCED ships only `{Time, Event}`. Fetch /equipment/rotator/info
+    /// to surface the current angle + mechanical position in the notification.
+    async fn handle_rotator_synced(&self, event: &Event) {
+        if self.chat_manager.service_count() == 0 {
+            return;
+        }
+        let info = self.client.get_rotator_info().await.ok();
+        self.send_rotator_synced_notification(event, info.as_ref())
+            .await;
+    }
+
+    /// FOCUSER-USER-FOCUSED ships only `{Time, Event}` (someone tweaked focus
+    /// manually). Fetch /equipment/focuser/info to surface the new position
+    /// + temperature.
+    async fn handle_focuser_user_focused(&self, event: &Event) {
+        if self.chat_manager.service_count() == 0 {
+            return;
+        }
+        let info = self.client.get_focuser_info().await.ok();
+        self.send_focuser_user_focused_notification(event, info.as_ref())
+            .await;
     }
 
     async fn handle_generic_event(&self, event: &Event) {
@@ -1161,6 +1186,61 @@ impl ChatUpdater {
             .await;
     }
 
+    async fn send_rotator_synced_notification(
+        &self,
+        event: &Event,
+        info: Option<&crate::rotator::RotatorInfoResponse>,
+    ) {
+        let mut message = ChatMessage::new(&self.titled("🧭 Rotator Synced"))
+            .color(colors::CYAN)
+            .field("Event", &event.event, true)
+            .field("Time", &event.time, true);
+        if let Some(info) = info
+            && info.response.connected
+        {
+            let r = &info.response;
+            message = message
+                .field("Position", &format!("{:.2}°", r.position), true)
+                .field(
+                    "Mechanical",
+                    &format!("{:.2}°", r.mechanical_position),
+                    true,
+                );
+            if r.synced {
+                message = message.field("Sync", "✅", true);
+            }
+        }
+        self.chat_manager
+            .send_message(&message, &self.chat_target)
+            .await;
+    }
+
+    async fn send_focuser_user_focused_notification(
+        &self,
+        event: &Event,
+        info: Option<&crate::focuser::FocuserInfoResponse>,
+    ) {
+        let mut message = ChatMessage::new(&self.titled("🔧 Focuser User-Focused"))
+            .color(colors::PURPLE)
+            .field("Event", &event.event, true)
+            .field("Time", &event.time, true);
+        if let Some(info) = info
+            && info.response.connected
+        {
+            let f = &info.response;
+            message = message.field("Position", &f.position.to_string(), true);
+            if !f.temperature.is_nan() {
+                message = message.field("Temperature", &format!("{:.1}°C", f.temperature), true);
+            }
+            if f.temp_comp_available {
+                message = message.field("Temp comp", if f.temp_comp { "on" } else { "off" }, true);
+            }
+        }
+        self.chat_manager
+            .send_message(&message, &self.chat_target)
+            .await;
+    }
+
     async fn send_generic_event_notification(&self, event: &Event) {
         let color = get_event_color(&event.event);
         let title = get_event_title(&event.event);
@@ -1198,6 +1278,12 @@ impl ChatUpdater {
                     message = message
                         .field("Position", &position.to_string(), true)
                         .field("HFR", &format!("{hfr:.3}"), true);
+                }
+                EventDetails::RotatorMoved { from, to } => {
+                    message = message
+                        .field("From", &format!("{from:.2}°"), true)
+                        .field("To", &format!("{to:.2}°"), true)
+                        .field("Δ", &format!("{:+.2}°", to - from), true);
                 }
             }
         }
@@ -1403,6 +1489,8 @@ fn get_event_title(event: &str) -> String {
         event_types::TS_TARGETSTART => "🎯 Target Started".to_string(),
         event_types::TS_WAITSTART => "⏳ Sequence Waiting".to_string(),
         event_types::AUTOFOCUS_POINT_ADDED => "📈 Autofocus Point".to_string(),
+        event_types::ROTATOR_MOVED => "🧭 Rotator Moved".to_string(),
+        event_types::ROTATOR_MOVED_MECHANICAL => "🧭 Rotator Moved (Mech.)".to_string(),
         _ => format!("📡 {}", event),
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -54,6 +54,14 @@ pub enum EventDetails {
         #[serde(rename = "HFR")]
         hfr: f64,
     },
+    /// Rotator moved. Emitted for both ROTATOR-MOVED and
+    /// ROTATOR-MOVED-MECHANICAL — both share `{From, To}` in degrees.
+    RotatorMoved {
+        #[serde(rename = "From")]
+        from: f64,
+        #[serde(rename = "To")]
+        to: f64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -521,6 +529,25 @@ mod tests {
                 assert!(coordinates.ra_string.is_empty());
             }
             other => panic!("expected TargetStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rotator_moved_event() {
+        let event_json = r#"{
+            "To": 104.04,
+            "Time": "2026-05-18T22:03:30.0844644-07:00",
+            "Event": "ROTATOR-MOVED",
+            "From": 0
+        }"#;
+        let event: Event = serde_json::from_str(event_json).unwrap();
+        assert_eq!(event.event, event_types::ROTATOR_MOVED);
+        match event.details {
+            Some(EventDetails::RotatorMoved { from, to }) => {
+                assert_eq!(from, 0.0);
+                assert!((to - 104.04).abs() < 1e-6);
+            }
+            other => panic!("expected RotatorMoved, got {other:?}"),
         }
     }
 

--- a/src/focuser.rs
+++ b/src/focuser.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct FocuserInfoResponse {
+    pub response: FocuserInfo,
+    pub error: String,
+    pub status_code: i32,
+    pub success: bool,
+    #[serde(rename = "Type")]
+    pub response_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct FocuserInfo {
+    pub connected: bool,
+    #[serde(default)]
+    pub position: i32,
+    #[serde(default)]
+    pub step_size: f64,
+    /// NINA returns this as a JSON *string* `"NaN"` when the focuser has
+    /// no temperature sensor (or is disconnected). Accept "NaN"/number/null.
+    #[serde(default, deserialize_with = "de_f64_or_nan_string")]
+    pub temperature: f64,
+    #[serde(default)]
+    pub is_moving: bool,
+    #[serde(default)]
+    pub is_settling: bool,
+    #[serde(default)]
+    pub temp_comp: bool,
+    #[serde(default)]
+    pub temp_comp_available: bool,
+}
+
+fn de_f64_or_nan_string<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    use serde::de::Error;
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| D::Error::custom("temperature not f64")),
+        serde_json::Value::String(s) => match s.as_str() {
+            "NaN" => Ok(f64::NAN),
+            "Infinity" => Ok(f64::INFINITY),
+            "-Infinity" => Ok(f64::NEG_INFINITY),
+            _ => s.parse::<f64>().map_err(D::Error::custom),
+        },
+        serde_json::Value::Null => Ok(f64::NAN),
+        other => Err(D::Error::custom(format!(
+            "expected number, NaN string, or null for temperature, got {other}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_live_focuser_info_nan_string() {
+        // c925 returns "NaN" as a string when the focuser temperature sensor
+        // is unavailable.
+        let json = r#"{"Response":{"Position":3325,"StepSize":1,"Temperature":"NaN","IsMoving":false,"IsSettling":false,"TempComp":false,"TempCompAvailable":false,"Connected":true},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: FocuserInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.response.connected);
+        assert_eq!(parsed.response.position, 3325);
+        assert!(parsed.response.temperature.is_nan());
+    }
+
+    #[test]
+    fn test_parse_focuser_with_real_temperature() {
+        let json = r#"{"Response":{"Position":3325,"StepSize":1,"Temperature":14.7,"IsMoving":false,"IsSettling":false,"TempComp":false,"TempCompAvailable":true,"Connected":true},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: FocuserInfoResponse = serde_json::from_str(json).unwrap();
+        assert!((parsed.response.temperature - 14.7).abs() < 1e-6);
+        assert!(parsed.response.temp_comp_available);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,12 @@ pub mod discord;
 pub mod error;
 pub mod events;
 pub mod filterwheel;
+pub mod focuser;
 pub mod guider;
 pub mod images;
 pub mod mount;
 pub mod poller;
+pub mod rotator;
 pub mod sequence;
 pub mod service_wrapper;
 #[cfg(windows)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1090,6 +1090,12 @@ fn display_last_events(events: &EventHistoryResponse, count: usize) {
                 EventDetails::AutofocusPointAdded { position, hfr } => {
                     println!("  Details: Autofocus point — position {position}, HFR {hfr:.3}");
                 }
+                EventDetails::RotatorMoved { from, to } => {
+                    println!(
+                        "  Details: Rotator moved {from:.2}° → {to:.2}° (Δ {:+.2}°)",
+                        to - from
+                    );
+                }
             }
         }
 

--- a/src/rotator.rs
+++ b/src/rotator.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RotatorInfoResponse {
+    pub response: RotatorInfo,
+    pub error: String,
+    pub status_code: i32,
+    pub success: bool,
+    #[serde(rename = "Type")]
+    pub response_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct RotatorInfo {
+    pub connected: bool,
+    #[serde(default)]
+    pub can_reverse: bool,
+    #[serde(default)]
+    pub reverse: bool,
+    #[serde(default)]
+    pub position: f64,
+    #[serde(default)]
+    pub mechanical_position: f64,
+    #[serde(default)]
+    pub step_size: f64,
+    #[serde(default)]
+    pub is_moving: bool,
+    #[serde(default)]
+    pub synced: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_live_rotator_info() {
+        let json = r#"{"Response":{"CanReverse":false,"Reverse":false,"MechanicalPosition":0,"Position":104.04,"StepSize":0.5,"IsMoving":false,"Synced":true,"Connected":true},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: RotatorInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(parsed.success);
+        assert!(parsed.response.connected);
+        assert!((parsed.response.position - 104.04).abs() < 1e-6);
+        assert!(parsed.response.synced);
+    }
+
+    #[test]
+    fn test_parse_disconnected_rotator() {
+        let json = r#"{"Response":{"CanReverse":false,"Reverse":false,"MechanicalPosition":0,"Position":0,"StepSize":0,"IsMoving":false,"Synced":false,"Connected":false},"Error":"","StatusCode":200,"Success":true,"Type":"API"}"#;
+        let parsed: RotatorInfoResponse = serde_json::from_str(json).unwrap();
+        assert!(!parsed.response.connected);
+    }
+}


### PR DESCRIPTION
## Summary

Three new enrichments based on a live event survey of c925:

| Event | Source of detail | What's new |
|---|---|---|
| `ROTATOR-MOVED` / `-MOVED-MECHANICAL` | payload (`From`/`To` in deg) | New `EventDetails::RotatorMoved` variant. Embed: `From / To / Δ`. |
| `ROTATOR-SYNCED` | `/equipment/rotator/info` | New `handle_rotator_synced` + `rotator.rs` module. Embed: position, mechanical position, sync status. |
| `FOCUSER-USER-FOCUSED` | `/equipment/focuser/info` | New `handle_focuser_user_focused` + `focuser.rs` module. Embed: position, temperature, temp-comp status. |

Focuser info ships `Temperature: "NaN"` as a JSON *string* when the sensor is unavailable — handled via a custom deserializer that accepts string `"NaN"`/`"Infinity"`/number/null and maps to `f64::NAN`. Display suppresses the field when NaN.

## Test plan

- [x] `cargo build`, `cargo test` (54 lib tests pass — added unit tests for rotator info parse, focuser info parse with `"NaN"` string, focuser info parse with real number, RotatorMoved event)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Live-payload survey against c925 (`ROTATOR-MOVED` shape confirmed, focuser `Temperature: "NaN"` confirmed)
- [ ] Live test in Discord: trigger a rotator move / sync, observe enriched embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)