### PR TITLE
refactor: drop dead code + fix stale comments

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -19,8 +19,6 @@ pub struct SpaceCatApiClient {
     retry_attempts: u32,
 }
 
-pub type SpaceCatClient = SpaceCatApiClient;
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct VersionResponse {
@@ -77,20 +75,6 @@ impl SpaceCatApiClient {
         })
     }
 
-    /// Create a new API client with default configuration
-    pub fn with_defaults() -> Result<Self, ApiError> {
-        Self::new(ApiConfig::default())
-    }
-
-    /// Create a new API client with a custom base URL
-    pub fn with_url(base_url: &str) -> Result<Self, ApiError> {
-        let config = ApiConfig {
-            base_url: base_url.to_string(),
-            ..ApiConfig::default()
-        };
-        Self::new(config)
-    }
-
     /// Fetch event history from the /event-history endpoint
     pub async fn get_event_history(&self) -> Result<EventHistoryResponse, ApiError> {
         self.get_event_history_with_params(&[]).await
@@ -101,16 +85,8 @@ impl SpaceCatApiClient {
         &self,
         params: &[(&str, &str)],
     ) -> Result<EventHistoryResponse, ApiError> {
-        self.request_with_retry("/event-history", params).await
-    }
-
-    /// Generic request method with retry logic
-    async fn request_with_retry(
-        &self,
-        endpoint: &str,
-        params: &[(&str, &str)],
-    ) -> Result<EventHistoryResponse, ApiError> {
-        self.generic_request_with_retry(endpoint, params).await
+        self.generic_request_with_retry("/event-history", params)
+            .await
     }
 
     /// Generic retry handler for any JSON response type
@@ -179,19 +155,6 @@ impl SpaceCatApiClient {
 
     /// Get API version (health check)
     pub async fn get_version(&self) -> Result<VersionResponse, ApiError> {
-        self.version_request_with_retry().await
-    }
-
-    /// Health check endpoint - returns true if API is available
-    pub async fn health_check(&self) -> Result<bool, ApiError> {
-        match self.get_version().await {
-            Ok(version_response) => Ok(version_response.success),
-            Err(_) => Ok(false),
-        }
-    }
-
-    /// Version request with retry logic
-    async fn version_request_with_retry(&self) -> Result<VersionResponse, ApiError> {
         self.generic_request_with_retry("/version", &[]).await
     }
 

--- a/src/chat/discord_bot.rs
+++ b/src/chat/discord_bot.rs
@@ -30,8 +30,7 @@ pub struct BotData {
     /// Discord channel ID -> telescope name. Slash commands invoked in a
     /// mapped channel default to that telescope.
     pub channel_to_telescope: HashMap<u64, String>,
-    /// Discord user IDs allowed to invoke write commands (Phase 3).
-    #[allow(dead_code)]
+    /// Discord user IDs allowed to invoke write commands.
     pub write_acl: std::collections::HashSet<u64>,
 }
 

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -762,7 +762,7 @@ impl ChatUpdater {
             self.state.last_image_time = Some(Instant::now());
             if self.state.skipped_images_count > 0 {
                 println!(
-                    "  Sent image to Discord (including {} skipped images)",
+                    "  Sent image notification (including {} skipped images)",
                     self.state.skipped_images_count
                 );
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,10 +73,6 @@ pub enum ChatError {
         service_name: String,
         reason: String,
     },
-
-    /// No chat services configured
-    #[error("No chat services are configured")]
-    NoServicesConfigured,
 }
 
 /// Service wrapper and Windows service errors
@@ -103,12 +99,6 @@ pub enum ServiceError {
     #[error("Tokio runtime error: {0}")]
     TokioRuntime(#[from] tokio::io::Error),
 }
-
-/// Result type alias for SpaceCat operations
-pub type Result<T> = std::result::Result<T, SpaceCatError>;
-
-/// Result type alias for Chat operations
-pub type ChatResult<T> = std::result::Result<T, ChatError>;
 
 /// Result type alias for Service operations
 pub type ServiceResult<T> = std::result::Result<T, ServiceError>;

--- a/src/events.rs
+++ b/src/events.rs
@@ -303,12 +303,6 @@ impl Event {
         }
         None
     }
-
-    /// Parse timestamp as std::time::SystemTime
-    pub fn parse_timestamp(&self) -> Result<std::time::SystemTime, Box<dyn std::error::Error>> {
-        // For now, just return current time - full parsing would need a date parsing library
-        Ok(std::time::SystemTime::now())
-    }
 }
 
 #[cfg(test)]

--- a/src/images.rs
+++ b/src/images.rs
@@ -223,12 +223,6 @@ impl ImageMetadata {
         )
     }
 
-    /// Parse timestamp as std::time::SystemTime
-    pub fn parse_timestamp(&self) -> Result<std::time::SystemTime, Box<dyn std::error::Error>> {
-        // For now, just return current time - full parsing would need a date parsing library
-        Ok(std::time::SystemTime::now())
-    }
-
     /// Get exposure time in minutes for easier reading
     pub fn exposure_time_minutes(&self) -> f64 {
         self.exposure_time / 60.0


### PR DESCRIPTION
## Summary

Small janitorial pass from the code-review punch list. No behavior change.

- **`api.rs`**: drop `SpaceCatClient` type alias, `with_defaults`, `with_url`, `health_check` (none used anywhere). Inline the 1-line `request_with_retry` and `version_request_with_retry` wrappers — they just forwarded to `generic_request_with_retry`.
- **`events.rs` / `images.rs`**: drop the stub `parse_timestamp` fns that returned `SystemTime::now()` with a "for now" comment. Doc lied; behavior was useless.
- **`error.rs`**: drop unused `NoServicesConfigured` variant and unused `Result<T>` / `ChatResult<T>` type aliases. `ServiceResult<T>` stays — it's used by `service_wrapper`.
- **`chat/discord_bot.rs`**: drop the stale `#[allow(dead_code)]` on `BotData.write_acl` — Phase 3 ACL checks use it.
- **`chat_updater.rs`**: rephrase "Sent image to Discord" log to be service-agnostic — the path may also hit Matrix or the bot.

Net diff: `6 files changed, 4 insertions(+), 64 deletions(-)`.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 54 lib tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)