### PR TITLE
refactor: purge unused fns / helpers / constants

### DIFF
--- a/examples/discord_webhook.rs
+++ b/examples/discord_webhook.rs
@@ -10,7 +10,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Example 1: Simple text message
     println!("Sending simple message...");
-    webhook.execute_simple("Hello from SpaceCat! 🔭").await?;
+    webhook
+        .execute(&WebhookMessage {
+            content: Some("Hello from SpaceCat! 🔭".to_string()),
+            ..Default::default()
+        })
+        .await?;
 
     // Example 2: Message with custom username and avatar
     println!("Sending custom message...");

--- a/src/autofocus.rs
+++ b/src/autofocus.rs
@@ -96,46 +96,6 @@ pub struct BacklashCompensation {
 }
 
 impl AutofocusResponse {
-    /// Get the calculated focus position
-    pub fn get_calculated_position(&self) -> i32 {
-        self.response.calculated_focus_point.position
-    }
-
-    /// Get the HFR (Half Flux Radius) value at the calculated focus position
-    pub fn get_calculated_hfr(&self) -> f64 {
-        self.response.calculated_focus_point.value
-    }
-
-    /// Get the filter used during autofocus
-    pub fn get_filter(&self) -> &str {
-        &self.response.filter
-    }
-
-    /// Get the temperature during autofocus
-    pub fn get_temperature(&self) -> f64 {
-        self.response.temperature
-    }
-
-    /// Get the autofocus duration
-    pub fn get_duration(&self) -> &str {
-        &self.response.duration
-    }
-
-    /// Get the method used for autofocus
-    pub fn get_method(&self) -> &str {
-        &self.response.method
-    }
-
-    /// Get the fitting method used
-    pub fn get_fitting(&self) -> &str {
-        &self.response.fitting
-    }
-
-    /// Get the number of measurement points taken
-    pub fn get_measurement_count(&self) -> usize {
-        self.response.measure_points.len()
-    }
-
     /// Get the best R-squared value among all fitting methods
     pub fn get_best_r_squared(&self) -> f64 {
         let r_squares = &self.response.r_squares;
@@ -172,11 +132,6 @@ impl AutofocusData {
             *positions.first().unwrap_or(&0),
             *positions.last().unwrap_or(&0),
         )
-    }
-
-    /// Get HFR values corresponding to focus positions
-    pub fn get_hfr_values(&self) -> Vec<f64> {
-        self.measure_points.iter().map(|p| p.value).collect()
     }
 
     /// Get the best HFR (lowest value) from all measurement points
@@ -247,14 +202,6 @@ mod tests {
         let response: AutofocusResponse = serde_json::from_str(&json_content).unwrap();
 
         // Test convenience methods
-        assert_eq!(response.get_calculated_position(), 4068);
-        assert_eq!(response.get_calculated_hfr(), 2.90813054456021);
-        assert_eq!(response.get_filter(), "OIII");
-        assert_eq!(response.get_temperature(), 21.3);
-        assert_eq!(response.get_method(), "STARHFR");
-        assert_eq!(response.get_fitting(), "TRENDHYPERBOLIC");
-        assert_eq!(response.get_measurement_count(), 10);
-
         // Test R-squared analysis
         let best_r_squared = response.get_best_r_squared();
         assert!(best_r_squared > 0.98); // Should be the hyperbolic fit (0.9894)
@@ -280,9 +227,6 @@ mod tests {
         assert!(positions.windows(2).all(|w| w[0] <= w[1])); // Check sorted
 
         // Test HFR analysis
-        let hfr_values = af_data.get_hfr_values();
-        assert_eq!(hfr_values.len(), 10);
-
         let best_hfr = af_data.get_best_measured_hfr().unwrap();
         assert!(best_hfr < 3.1); // Should find the minimum HFR (around 3.009)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -241,25 +241,6 @@ impl Config {
         Ok(config)
     }
 
-    /// Load configuration from default file (config.json)
-    pub fn load_default() -> Result<Self, ConfigError> {
-        Self::load_from_file("config.json")
-    }
-
-    /// Load configuration with fallback to default
-    pub fn load_or_default() -> Self {
-        match Self::load_default() {
-            Ok(config) => {
-                println!("Loaded configuration from config.json");
-                config
-            }
-            Err(e) => {
-                println!("Failed to load config.json ({e}), using defaults");
-                Self::default()
-            }
-        }
-    }
-
     /// Load configuration from specified file with fallback to default
     pub fn load_or_default_from<P: AsRef<Path>>(path: P) -> Self {
         let path_ref = path.as_ref();
@@ -284,17 +265,6 @@ impl Config {
         let json = serde_json::to_string_pretty(self)?;
         fs::write(path, json)?;
         Ok(())
-    }
-
-    /// Save configuration to default file (config.json)
-    pub fn save_default(&self) -> Result<(), ConfigError> {
-        self.save_to_file("config.json")
-    }
-
-    /// Create a sample configuration file
-    pub fn create_sample_config<P: AsRef<Path>>(path: P) -> Result<(), ConfigError> {
-        let sample_config = Self::default();
-        sample_config.save_to_file(path)
     }
 
     /// Look up a telescope by name. If `name` is None and there's exactly one

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -8,7 +8,7 @@ pub struct DiscordWebhook {
     webhook_url: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct WebhookMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
@@ -242,24 +242,6 @@ impl DiscordWebhook {
         Ok(())
     }
 
-    pub async fn execute_simple(&self, content: &str) -> Result<(), DiscordError> {
-        let message = WebhookMessage {
-            content: Some(content.to_string()),
-            username: None,
-            avatar_url: None,
-            tts: None,
-            embeds: None,
-            allowed_mentions: None,
-            components: None,
-            files: None,
-            payload_json: None,
-            attachments: None,
-            flags: None,
-        };
-
-        self.execute(&message).await
-    }
-
     pub async fn execute_with_embed(
         &self,
         content: Option<&str>,
@@ -447,8 +429,5 @@ pub mod colors {
     pub const PURPLE: u32 = 0x800080;
     pub const ORANGE: u32 = 0xFFA500;
     pub const CYAN: u32 = 0x00FFFF;
-    pub const PINK: u32 = 0xFFC0CB;
-    pub const WHITE: u32 = 0xFFFFFF;
-    pub const BLACK: u32 = 0x000000;
     pub const GRAY: u32 = 0x808080;
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -208,14 +208,6 @@ impl EventHistoryResponse {
             .collect()
     }
 
-    /// Get events in a time range (assuming ISO 8601 timestamps)
-    pub fn get_events_in_range(&self, start: &str, end: &str) -> Vec<&Event> {
-        self.response
-            .iter()
-            .filter(|event| event.time.as_str() >= start && event.time.as_str() <= end)
-            .collect()
-    }
-
     /// Count events by type
     pub fn count_events_by_type(&self) -> std::collections::HashMap<String, usize> {
         let mut counts = std::collections::HashMap::new();
@@ -230,26 +222,6 @@ impl Event {
     /// Check if this is a connection event
     pub fn is_connection_event(&self) -> bool {
         self.event.ends_with("-CONNECTED") || self.event.ends_with("-DISCONNECTED")
-    }
-
-    /// Check if this is a disconnection event
-    pub fn is_disconnection(&self) -> bool {
-        self.event.ends_with("-DISCONNECTED")
-    }
-
-    /// Check if this is a connection event
-    pub fn is_connection(&self) -> bool {
-        self.event.ends_with("-CONNECTED")
-    }
-
-    /// Get the equipment name from the event (e.g., "CAMERA" from "CAMERA-CONNECTED")
-    pub fn get_equipment_name(&self) -> Option<&str> {
-        if self.is_connection_event()
-            && let Some(pos) = self.event.rfind('-')
-        {
-            return Some(&self.event[..pos]);
-        }
-        None
     }
 }
 
@@ -299,22 +271,14 @@ mod tests {
             event: event_types::CAMERA_CONNECTED.to_string(),
             details: None,
         };
-
         assert!(camera_connected.is_connection_event());
-        assert!(camera_connected.is_connection());
-        assert!(!camera_connected.is_disconnection());
-        assert_eq!(camera_connected.get_equipment_name(), Some("CAMERA"));
 
         let mount_disconnected = Event {
             time: "2025-08-06T19:20:35.2068582-07:00".to_string(),
             event: event_types::MOUNT_DISCONNECTED.to_string(),
             details: None,
         };
-
         assert!(mount_disconnected.is_connection_event());
-        assert!(!mount_disconnected.is_connection());
-        assert!(mount_disconnected.is_disconnection());
-        assert_eq!(mount_disconnected.get_equipment_name(), Some("MOUNT"));
     }
 
     #[test]
@@ -558,14 +522,6 @@ mod tests {
 
             let autofocus_events = events.get_events_by_type(event_types::AUTOFOCUS_FINISHED);
             println!("Found {} autofocus events", autofocus_events.len());
-
-            // Test time range filtering (get first and last event times)
-            if events.response.len() > 1 {
-                let first_time = &events.response[0].time;
-                let last_time = &events.response[events.response.len() - 1].time;
-                let range_events = events.get_events_in_range(first_time, last_time);
-                assert_eq!(range_events.len(), events.response.len());
-            }
         } else {
             println!("example_event-history.json not found, skipping file test");
         }

--- a/src/images.rs
+++ b/src/images.rs
@@ -60,17 +60,6 @@ pub mod image_types {
     pub const BIAS: &str = "BIAS";
 }
 
-// Common filter constants
-pub mod filters {
-    pub const LUMINANCE: &str = "L";
-    pub const RED: &str = "R";
-    pub const GREEN: &str = "G";
-    pub const BLUE: &str = "B";
-    pub const HYDROGEN_ALPHA: &str = "HA";
-    pub const OXYGEN_III: &str = "OIII";
-    pub const SULFUR_II: &str = "SII";
-}
-
 impl ImageHistoryResponse {
     /// Get all images of a specific type (LIGHT, DARK, FLAT, BIAS)
     pub fn get_images_by_type(&self, image_type: &str) -> Vec<&ImageMetadata> {
@@ -102,26 +91,6 @@ impl ImageHistoryResponse {
                     || image.image_type == image_types::FLAT
                     || image.image_type == image_types::BIAS
             })
-            .collect()
-    }
-
-    /// Get images in a temperature range
-    pub fn get_images_in_temperature_range(
-        &self,
-        min_temp: f64,
-        max_temp: f64,
-    ) -> Vec<&ImageMetadata> {
-        self.response
-            .iter()
-            .filter(|image| image.temperature >= min_temp && image.temperature <= max_temp)
-            .collect()
-    }
-
-    /// Get images with specific exposure time
-    pub fn get_images_by_exposure_time(&self, exposure_time: f64) -> Vec<&ImageMetadata> {
-        self.response
-            .iter()
-            .filter(|image| (image.exposure_time - exposure_time).abs() < 0.001)
             .collect()
     }
 
@@ -206,27 +175,6 @@ impl ImageMetadata {
             || self.image_type == image_types::FLAT
             || self.image_type == image_types::BIAS
     }
-
-    /// Check if this is a broadband filter (LRGB)
-    pub fn is_broadband_filter(&self) -> bool {
-        matches!(
-            self.filter.as_str(),
-            filters::LUMINANCE | filters::RED | filters::GREEN | filters::BLUE
-        )
-    }
-
-    /// Check if this is a narrowband filter
-    pub fn is_narrowband_filter(&self) -> bool {
-        matches!(
-            self.filter.as_str(),
-            filters::HYDROGEN_ALPHA | filters::OXYGEN_III | filters::SULFUR_II
-        )
-    }
-
-    /// Get exposure time in minutes for easier reading
-    pub fn exposure_time_minutes(&self) -> f64 {
-        self.exposure_time / 60.0
-    }
 }
 
 #[cfg(test)]
@@ -292,9 +240,6 @@ mod tests {
 
         assert!(light_frame.is_light_frame());
         assert!(!light_frame.is_calibration_frame());
-        assert!(!light_frame.is_broadband_filter());
-        assert!(light_frame.is_narrowband_filter());
-        assert_eq!(light_frame.exposure_time_minutes(), 3.0);
 
         let flat_frame = ImageMetadata {
             exposure_time: 1.0,
@@ -318,8 +263,6 @@ mod tests {
 
         assert!(!flat_frame.is_light_frame());
         assert!(flat_frame.is_calibration_frame());
-        assert!(flat_frame.is_broadband_filter());
-        assert!(!flat_frame.is_narrowband_filter());
     }
 
     #[test]

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -30,11 +30,6 @@ impl EventPoller {
         }
     }
 
-    /// Create a new event poller with default 5-second poll interval
-    pub fn new_with_default_interval(client: SpaceCatApiClient) -> Self {
-        Self::new(client, Duration::from_secs(5))
-    }
-
     /// Poll for new events and return only events not seen before
     pub async fn poll_new_events(&mut self) -> Result<PollResult, Box<dyn std::error::Error>> {
         let start_time = Instant::now();
@@ -63,51 +58,9 @@ impl EventPoller {
         })
     }
 
-    /// Poll continuously and call a callback function for each batch of new events
-    pub async fn poll_continuously<F, Fut>(
-        &mut self,
-        mut callback: F,
-    ) -> Result<(), Box<dyn std::error::Error>>
-    where
-        F: FnMut(PollResult) -> Fut,
-        Fut: std::future::Future<Output = Result<(), Box<dyn std::error::Error>>>,
-    {
-        loop {
-            match self.poll_new_events().await {
-                Ok(result) => {
-                    if !result.new_events.is_empty()
-                        && let Err(e) = callback(result).await
-                    {
-                        eprintln!("Callback error: {e}");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Polling error: {e}");
-                    // Sleep longer on error to avoid spamming
-                    sleep(Duration::from_secs(30)).await;
-                }
-            }
-        }
-    }
-
     /// Get the number of unique events seen so far
     pub fn seen_event_count(&self) -> usize {
         self.seen_events.len()
-    }
-
-    /// Clear the seen events cache (useful for testing or reset scenarios)
-    pub fn reset_seen_events(&mut self) {
-        self.seen_events.clear();
-    }
-
-    /// Set a new poll interval
-    pub fn set_poll_interval(&mut self, interval: Duration) {
-        self.poll_interval = interval;
-    }
-
-    /// Get the current poll interval
-    pub fn poll_interval(&self) -> Duration {
-        self.poll_interval
     }
 
     /// Find new events by comparing against previously seen events
@@ -177,7 +130,7 @@ mod tests {
     async fn test_event_key_creation() {
         let config = ApiConfig::default();
         let client = SpaceCatApiClient::new(config).unwrap();
-        let poller = EventPoller::new_with_default_interval(client);
+        let poller = EventPoller::new(client, Duration::from_secs(5));
 
         let event = Event {
             time: "2023-01-01T12:00:00".to_string(),


### PR DESCRIPTION
## Summary

Sweep of items the code review flagged as having no production callers. Where a method was only referenced by its own unit test, the test assertion is dropped along with the function.

**Stacked on #82** (the consolidation PR). Rebases cleanly onto main if #82 lands first.

| File | Removed |
|---|---|
| `config.rs` | `load_default`, `load_or_default`, `save_default`, `create_sample_config` |
| `poller.rs` | `new_with_default_interval`, `poll_continuously`, `reset_seen_events`, `set_poll_interval`, `poll_interval()` |
| `events.rs` | `Event::{is_connection, is_disconnection, get_equipment_name}`, `EventHistoryResponse::get_events_in_range` |
| `images.rs` | `ImageMetadata::{is_broadband_filter, is_narrowband_filter, exposure_time_minutes}`, `ImageHistoryResponse::{get_images_in_temperature_range, get_images_by_exposure_time}`, plus the now-unused `filters::*` color constants |
| `autofocus.rs` | Eight wrapper getters on `AutofocusResponse` (`get_calculated_position`, `get_calculated_hfr`, `get_filter`, `get_temperature`, `get_duration`, `get_method`, `get_fitting`, `get_measurement_count`) — callers reach in via `.response.X` fields directly. Also `AutofocusData::get_hfr_values`. |
| `discord.rs` | `execute_simple` (one-liner over `execute`); `colors::{PINK, WHITE, BLACK}` |

Production behavior preserved:
- `Event::is_connection_event` stays — used by the equipment-event filter on `EventHistoryResponse`.
- `EventPoller::last_poll_time` stays — it's the rate limiter inside `poll_new_events` and `cmd_poll` relies on it.
- `config::save_to_file` stays — Windows service uses it.
- `WebhookMessage` now derives `Default` so callers can `..Default::default()` for content-only messages.

`examples/discord_webhook.rs` updated to call `execute` with a default-constructed `WebhookMessage` (replacing the deleted `execute_simple`).

Net diff: `7 files changed, 8 insertions(+), 258 deletions(-)`.

## Test plan

- [x] `cargo build --all-targets` clean (examples included)
- [x] `cargo test` — 61 lib tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)