### PR TITLE
fix(security): bump quinn-proto and anyhow (RUSTSEC-2026-0185 / -0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap2"
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Problem
The **Security Audit** CI job (`cargo audit`) is failing on `main`:

```
error: 1 vulnerability found!
Crate:   quinn-proto
Title:   Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
ID:      RUSTSEC-2026-0185
```

`quinn` is an **optional, unbuilt** transitive of `reqwest`'s HTTP/3 feature — present only in `Cargo.lock`, never compiled — but `cargo audit` scans the lockfile regardless.

## Fix
Lockfile-only bumps to the patched releases:

| Crate | From | To | Advisory |
| ----- | ---- | -- | -------- |
| `quinn-proto` | 0.11.14 | 0.11.15 | RUSTSEC-2026-0185 (vuln — was failing CI) |
| `anyhow` | 1.0.102 | 1.0.103 | RUSTSEC-2026-0190 (unsound `Error::downcast_mut()`) |

Both patched versions confirmed against the advisories (`>=0.11.15`, `>=1.0.103`).

## Verification
- `cargo audit` → **exit 0** (was exit 1).
- `cargo check` → clean.
- Remaining `cargo audit` output is only two pre-existing `unmaintained` **warnings** (`derivative`, `proc-macro-error2`), which do not fail the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)