### PR TITLE
Fix cargo fmt CI lint failure; bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "spacecat"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spacecat"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["SpaceCat Contributors"]

--- a/packaging/rpm/spacecat.spec
+++ b/packaging/rpm/spacecat.spec
@@ -6,7 +6,7 @@
 %global debug_package %{nil}
 
 Name:           spacecat
-Version:        0.2.0
+Version:        0.2.1
 Release:        1%{?dist}
 Summary:        SpaceCat - Astronomical Observation System
 
@@ -106,6 +106,9 @@ install -Dpm0640 packaging/rpm/spacecat-default.json \
 %attr(0640,root,spacecat) %config(noreplace) %{_sysconfdir}/%{name}/config.json
 
 %changelog
+* Thu Jul 02 2026 Yann Ramin <github@theatr.us> - 0.2.1-1
+- Fix `cargo fmt` violations that broke CI linting on main
+
 * Thu Jul 02 2026 Yann Ramin <github@theatr.us> - 0.2.0-1
 - Add exponential-backoff reconnect logic for offline telescopes, with
   configurable per-telescope thresholds and debounced chat alerts on

--- a/src/chat_updater.rs
+++ b/src/chat_updater.rs
@@ -243,9 +243,7 @@ impl ChatUpdater {
             match self.initialize_baseline().await.map_err(|e| e.to_string()) {
                 Ok(()) => break,
                 Err(msg) => {
-                    eprintln!(
-                        "[{n}] Failed to initialize baseline: {msg}; retrying in {delay:?}"
-                    );
+                    eprintln!("[{n}] Failed to initialize baseline: {msg}; retrying in {delay:?}");
                     sleep(delay).await;
                     delay = self.next_reconnect_delay(delay);
                 }
@@ -300,8 +298,7 @@ impl ChatUpdater {
             }
         } else {
             self.state.consecutive_failures += 1;
-            if self.state.connected
-                && self.state.consecutive_failures >= OFFLINE_FAILURE_THRESHOLD
+            if self.state.connected && self.state.consecutive_failures >= OFFLINE_FAILURE_THRESHOLD
             {
                 eprintln!(
                     "[{}] Telescope offline after {} failed cycles; backing off.",
@@ -1672,7 +1669,10 @@ mod tests {
         let initial = Duration::from_secs(60);
         let max = Duration::from_secs(600);
         // 60 -> 120 -> 240 -> 480 -> 600 (capped) -> 600 (stays)
-        assert_eq!(backoff_delay(initial, initial, max), Duration::from_secs(120));
+        assert_eq!(
+            backoff_delay(initial, initial, max),
+            Duration::from_secs(120)
+        );
         assert_eq!(
             backoff_delay(Duration::from_secs(120), initial, max),
             Duration::from_secs(240)
@@ -1709,6 +1709,9 @@ mod tests {
         let initial = Duration::from_secs(60);
         let max = Duration::from_secs(10);
         assert_eq!(backoff_delay(initial, initial, max), initial);
-        assert_eq!(backoff_delay(Duration::from_secs(120), initial, max), initial);
+        assert_eq!(
+            backoff_delay(Duration::from_secs(120), initial, max),
+            initial
+        );
     }
 }

--- a/src/service_wrapper.rs
+++ b/src/service_wrapper.rs
@@ -236,7 +236,11 @@ mod windows_service_impl {
                             }
                             // Map the (non-Send) error to a String so no
                             // `Box<dyn Error>` is held across the await below.
-                            match updater.initialize_baseline().await.map_err(|e| e.to_string()) {
+                            match updater
+                                .initialize_baseline()
+                                .await
+                                .map_err(|e| e.to_string())
+                            {
                                 Ok(()) => break,
                                 Err(msg) => {
                                     eprintln!(


### PR DESCRIPTION
## Summary
- `main`'s "Check formatting" CI job has been failing since #92 (the reconnect-backoff PR) merged without a `cargo fmt` pass.
- Runs `cargo fmt` to fix the four affected spots in `src/chat_updater.rs` and `src/service_wrapper.rs` — no behavior change.
- Bumps version to 0.2.1 (patch) since this is a fix on top of the just-released 0.2.0, and syncs the RPM spec version/changelog.

## Test plan
- [x] `cargo fmt --check` (clean)
- [x] `cargo clippy` (clean)
- [x] `cargo build`
- [x] `cargo test` (65 passed)
- [ ] Confirm CI is green on this PR before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)