### PR TITLE
ci: install prebuilt cargo-audit; point Dependabot reviews at theatrus

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
       time: "09:00"
     open-pull-requests-limit: 10
     reviewers:
-      - "@me"
+      - "theatrus"
     assignees:
-      - "@me"
+      - "theatrus"
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"
@@ -26,9 +26,9 @@ updates:
       time: "09:00"
     open-pull-requests-limit: 5
     reviewers:
-      - "@me"
+      - "theatrus"
     assignees:
-      - "@me"
+      - "theatrus"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
 
       - name: Run security audit
         run: cargo audit


### PR DESCRIPTION
## Summary
- The Security Audit job failed on every branch because it compiled cargo-audit from source with the repo-pinned Rust 1.93.0 toolchain, and cargo-audit's dependency `kstring@2.0.4` now requires rustc 1.96. Install the prebuilt binary via `taiki-e/install-action@cargo-audit` instead, which does not use the repo toolchain and is immune to future MSRV drift.
- Replace the invalid `@me` Dependabot reviewer/assignee with `theatrus`.

`cargo audit` itself passes locally (only allowed warnings), so this unblocks the seven open Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)